### PR TITLE
Backport fix: don't import path from Rsamtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Imports: XML (>= 1.98-0), BiocGenerics (>= 0.13.8),
          S4Vectors (>= 0.13.13), IRanges (>= 2.11.12), XVector (>= 0.9.4),
          GenomeInfoDb (>= 1.3.14),
          Biostrings (>= 2.43.7), zlibbioc, RCurl (>= 1.4-2),
-         Rsamtools (>= 1.17.8), GenomicAlignments (>= 1.5.4), tools
+         Rsamtools (>= 1.25.2), GenomicAlignments (>= 1.5.4), tools
 Suggests: BSgenome (>= 1.33.4), humanStemCell, microRNA (>= 1.1.1), genefilter,
           limma, org.Hs.eg.db, hgu133plus2.db, GenomicFeatures,
           BSgenome.Hsapiens.UCSC.hg19, TxDb.Hsapiens.UCSC.hg19.knownGene,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -47,7 +47,7 @@ importMethodsFrom("Biostrings", masks, "masks<-", getSeq)
 importClassesFrom("Biostrings", DNAStringSet, XStringSet)
 
 importFrom("Rsamtools", indexTabix, bgzip, TabixFile, index)
-importMethodsFrom("Rsamtools", ScanBamParam, asBam, headerTabix, isOpen, path,
+importMethodsFrom("Rsamtools", ScanBamParam, asBam, headerTabix, isOpen,
                   scanTabix)
 importClassesFrom("Rsamtools", RsamtoolsFile, TabixFile, BamFile)
 


### PR DESCRIPTION
Rsamtools stopped exporting `path` at version 1.25.2, and their Bioc 3.6 release is now at 1.30. At present `rtracklayer` appears to be broken when installing from bioconda due to the combination of this issue, and the unavailability of older versions of Rsamtools.