### PR TITLE
BiocIO additional updates

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -69,7 +69,7 @@ exportClasses(BrowserSession, BrowserView, BrowserViewList,
               TrackHub, TrackHubGenome, Track, TrackContainer)
 
 ## File classes
-exportClasses(RTLFile, RTLFileList, CompressedFile, GFFFile, UCSCFile, BEDFile,
+exportClasses(RTLFile, RTLFileList, GFFFile, UCSCFile, BEDFile,
               WIGFile, ChainFile, FastaFile, GFF1File, GFF2File, GFF3File,
               BEDGraphFile, BED15File, GTFFile, GVFFile, BigWigFile,
               BigWigFileList, BigBedFile, TwoBitFile, BEDPEFile)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,7 +14,7 @@ import(zlibbioc)
 
 importFrom("stats", offset, setNames)
 importFrom("utils", count.fields, URLdecode, URLencode, browseURL,
-           download.file, read.table, type.convert, write.table,
+           download.file, read.table, read.csv, type.convert, write.table,
            packageVersion, strcapture)
 importFrom("tools", file_path_as_absolute, file_ext, file_path_sans_ext)
 importFrom("grDevices", col2rgb, rgb)
@@ -23,7 +23,7 @@ importFrom("grDevices", col2rgb, rgb)
 ### Non-bioconductor packages
 ###
 
-importFrom("XML", getNodeSet, xmlValue, xmlAttrs, htmlTreeParse,
+importFrom("XML", getNodeSet, xmlValue, xmlAttrs, htmlTreeParse, xmlTreeParse,
            xmlInternalTreeParse, parseURI, newXMLNode, xmlChildren,
            addChildren, removeChildren, readHTMLTable)
 importMethodsFrom("XML", saveXML)

--- a/R/bigBed.R
+++ b/R/bigBed.R
@@ -6,7 +6,7 @@
 ### Classes
 ###
 
-setClass("BigBedFile", contains = "RTLFile")
+setClass("BigBedFile", contains = "BiocFile")
 setClass("BBFile", contains = "BigBedFile")
 
 BigBedFile <- function(path) {

--- a/R/chain.R
+++ b/R/chain.R
@@ -86,7 +86,7 @@ flipStrandTricky <- function(strand, flip) {
 
 smoothGaps <- function(qhits, ranges, offsets) {
     congruent_gaps <- width(gaps(ranges)) == abs(offsets)
-    congruent_gaps_rle <- Rle(congruent)
+    congruent_gaps_rle <- Rle(congruent_gaps)
     congruent_rle <- c(Rle(FALSE), congruent_gaps_rle)
     group_rle <- Rle(cumsum(!congruent_rle))
     group_ranges <- disjoin(ranges(Rle(qhits)), ranges(group_rle))

--- a/R/io.R
+++ b/R/io.R
@@ -94,7 +94,7 @@ normURI <- function(x) {
     stop("URI must be a single, non-NA string")
   uri <- .parseURI(x)
   if (uri$scheme == "") # /// (vs. //) needed for Windows
-    x <- paste("/", file_path_as_absolute(x), sep = "")
+    x <- paste("file:///", file_path_as_absolute(x), sep = "")
   x
 }
 

--- a/R/io.R
+++ b/R/io.R
@@ -118,7 +118,7 @@ createResource <- function(x, dir = FALSE, content = "") {
 
 uriExists <- function(x) {
   uri <- .parseURI(x)
-  if (uriIsLocal(x)) {
+  if (uriIsLocal(uri)) {
     exists <- file.exists(uri$path)
   } else {
     txt <- getURL(x, header = TRUE)

--- a/R/io.R
+++ b/R/io.R
@@ -7,13 +7,6 @@ setMethod("initialize", "RTLFile", function(.Object, ...) {
     callNextMethod()
 })
 
-setClass("CompressedFile", contains = c("RTLFile", "VIRTUAL"))
-
-setMethod("initialize", "CompressedFile", function(.Object, ...) {
-    .Deprecated("CompressedFile", msg = "This class is extending the deprecated CompressedFile class from rtracklayer. Use CompressedFile from BiocIO in place of CompressedFile from rtracklayer.")
-    callNextMethod()
-})
-
 setClass("RTLFileList",
          prototype = prototype(elementType = "RTLFile"),
          contains = "SimpleList")

--- a/R/trackhub.R
+++ b/R/trackhub.R
@@ -286,7 +286,7 @@ Genome <- function(...) {
 }
 
 stopIfNotGenome <- function(x) {
-    if (!is(value, "Genome"))
+    if (!is(x, "Genome"))
         stop("value must be Genome object")
 }
 

--- a/R/trackhub.R
+++ b/R/trackhub.R
@@ -938,7 +938,7 @@ setReplaceMethod("track",
                  })
 
 setReplaceMethod("track",
-                 signature(object = "TrackHubGenome", value = "RTLFile"),
+                 signature(object = "TrackHubGenome", value = "BiocFile"),
                  function(object, name, ..., value)
                  {
                      if (missing(name))

--- a/man/BigBedFile.Rd
+++ b/man/BigBedFile.Rd
@@ -84,7 +84,7 @@ export.bb(object, con, ...)
 
 \section{\code{BigBedFile} objects}{
   A \code{BigWigFile} object, an extension of
-  \code{\linkS4class{RTLFile}} is a reference to a BigBed file. To cast
+  \code{\linkS4class{BiocFile}} is a reference to a BigBed file. To cast
   a path, URL or connection to a \code{BigBedFile}, pass it to the
   \code{BigBedFile} constructor.
 

--- a/man/TrackHubGenome-class.Rd
+++ b/man/TrackHubGenome-class.Rd
@@ -116,7 +116,7 @@
         Currently, supported \code{value} types include a
         \code{GenomicRanges}, \code{GRangesList}, or a file resource
         (copied to the repository).  The file resource may be
-        represented as a path, URL, \code{\linkS4class{RTLFile}} or
+        represented as a path, URL, \code{\linkS4class{BiocFile}} or
         \code{\link[Rsamtools:RsamtoolsFile-class]{RsamtoolsFile}}. If
         not a file name, \code{value} is written in \code{format}. For
         generic interval data, this means a BigWig file (if there is a


### PR DESCRIPTION
The intention of the pull request is to clean up addition issues related to creation of the BiocIO package.

https://github.com/lawremi/rtracklayer/commit/561cc87b59da5872a76595398a77def19141d9cb is initial clean-up reduces some of the warnings, unrelated to BiocIO.

https://github.com/lawremi/rtracklayer/commit/d2956a64d53204c7dc3a8ffaf6473e95c55c87fc removes the CompressedFile class definition, even though we would have liked to keep it to signal a warning about deprecation; having identical class names in BiocIO and rtacklayer seems to cause problems as documented in the commit message.

https://github.com/lawremi/rtracklayer/commit/ec57795c8c222d41839dabb2cf9f9c00ca3e7557 replaces RTLFile with BiocFile in a couple of places in the code and documentation.

The last commit https://github.com/lawremi/rtracklayer/commit/47f3bfb759d63d443dcedefd87fb145fa83b1f0e may need some attention -- it reverts a portion of a commit from a few days ago that nonetheless breaks, e.g., `?TrackHubGenome`.

A version bump is required.