### PR TITLE
UCSC Table query improvements

### DIFF
--- a/R/ucsc.R
+++ b/R/ucsc.R
@@ -391,11 +391,12 @@ setMethod("tableNames", "UCSCTableQuery",
               url <- RestUri(paste0(object@url, "hubApi"))
               response <- read(url$list$tracks, genome = genome, trackLeavesOnly = 1)
               names <- names(response[[genome]])
-              protectedStatus <- vapply(response[[genome]], function(x) {
-                if (is.null(x$protectedData)) TRUE
-                else FALSE
-              }, logical(1L))
-              names[protectedStatus]
+              tables <- mapply(function(name, response) {
+                                   if (!is.null(response$protectedData)) NULL
+                                   else if (!is.null(response$table)) response$table
+                                   else name
+                          }, names, response[[genome]])
+              Filter(Negate(is.null), tables)
             }
           })
 

--- a/R/ucsc.R
+++ b/R/ucsc.R
@@ -152,7 +152,8 @@ setClass("UCSCTableQuery",
                         range = "GRanges",
                         NAMES = "character_OR_NULL",
                         url = "character",
-                        hubUrl = "character_OR_NULL"))
+                        hubUrl = "character_OR_NULL",
+                        track = "character_OR_NULL"))
 
 setMethod("show", "UCSCTableQuery",
           function(object) {
@@ -322,7 +323,7 @@ setMethod("ucscTableQuery", "character",
                 range <- as(range, "GRanges")
               } else range <- normTableQueryRange(range, genome)
               query <- new("UCSCTableQuery", genome = genome, range = range,
-                          NAMES = names, url = url, hubUrl = hubUrl)
+                          NAMES = names, url = url, hubUrl = hubUrl, track = track)
               if (is.null(table))
                 check <- FALSE
               tableName(query, check=check) <- table
@@ -384,7 +385,9 @@ setMethod("tableNames", "UCSCTableQuery",
             if (trackOnly)
               warning("track is meaningless now you only go by the table")
             genome <- object@genome
-            if (isTrackHub(object)) {
+            if (!is.null(object@track)) {
+              ucscTables(object@genome, object@track)
+            } else if (isTrackHub(object)) {
               th <- TrackHub(object@hubUrl)
               names(th[[genome]])
             } else {

--- a/R/ucsc.R
+++ b/R/ucsc.R
@@ -492,7 +492,7 @@ setMethod("track", "UCSCTableQuery",
                                   end = table[["end"]]), strand = table[["strand"]])
 
               # remove used columns
-              table[["chrom"]] = table[["strand"]] = table[["start"]] = table[["end"]] = NULL
+              table[["chrom"]] <- table[["strand"]] <- table[["start"]] <- table[["end"]] <- NULL
               # add left columns to the GRange object
               elementMetadata(output) <- table
               genome(output) <- object@genome

--- a/inst/unitTests/test_ucsc.R
+++ b/inst/unitTests/test_ucsc.R
@@ -10,16 +10,16 @@ test_ucsc <- function(x) {
     custom_range <- GRangesForUCSCGenome(genome, "chr1", IRanges(67003232, 67132477))
     selected_table <- data.frame(bin = 963, chrom = "chr5", chromStart = 49656261,
                                  chromEnd = 49661871, ix = 804, type ="W", frag="ABBA01004242.1",
-                                 fragStart = 0, fragEnd = 5610, strand = "+", tracktype = "bed")
+                                 fragStart = 0, fragEnd = 5610, strand = "+")
 
     # creating a track and a table for UCSCSession and genome identifier
     elementMetadata  <- list(bin = 0, ix = 1060, type = "F", frag = "AL133320.8",
-                             fragStart = 2000, fragEnd = 131245, tracktype = "bed")
+                             fragStart = 2000, fragEnd = 131245)
     track <- GRanges("chr1", IRanges(67003232, 67132477), "+", elementMetadata)
     genome(track) <- genome
     table <- data.frame(bin = 0, chrom = "chr1", chromStart = 67003232, chromEnd = 67132477,
                         ix = 1060, type = "F", frag = "AL133320.8", fragStart = 2000, 
-                        fragEnd = 131245,strand = "+", tracktype = "bed")
+                        fragEnd = 131245,strand = "+")
 
 
     test_trackhub_path <- system.file("tests", "trackhub", package = "rtracklayer")


### PR DESCRIPTION
The purpose of this PR is to fix and clean up the UCSC table query interface

https://github.com/lawremi/rtracklayer/commit/f99d9fb56ea4ab670d37c56bd31bfbdbab7b544a: Fix `tableNames()` method logic to retrieve correct table names

https://github.com/lawremi/rtracklayer/commit/1851134d17507c11feb83bc7977605bbb7cf2073: Make `tableNames()` method backward compatible

https://github.com/lawremi/rtracklayer/commit/98a615775e9514b170c8c8f6a78071993cf286a4: Clean JSON parsing logic and related methods (`tableNames()` and  `getTable()`)