### PR TITLE
bugfix: get seqinfo from metadata first

### DIFF
--- a/R/quickload.R
+++ b/R/quickload.R
@@ -156,10 +156,14 @@ setMethod("toString", "GenomeDescription", function(x) {
 ## Not sure where this method should land. I'm sure it will be useful
 ## for publishing adhoc genomes through Quickload.
 setMethod("seqinfo", "DNAStringSet", function(x) {
-  x_names <- names(x)
-  if (is.null(x_names))
-    x_names <- as.character(seq(length(x)))
-  Seqinfo(x_names, width(x))
+  si <- metadata(x)$seqinfo
+  if (is.null(si)) {
+      x_names <- names(x)
+      if (is.null(x_names))
+        x_names <- as.character(seq(length(x)))
+      si <- Seqinfo(x_names, width(x))
+  }
+  si
 })
 
 QuickloadGenome <- function(quickload, genome, create = FALSE,


### PR DESCRIPTION
Hi Michael, @lawremi 

This is the initial step to untangling these dependencies: 
https://github.com/Bioconductor/BSgenome/issues/17
https://support.bioconductor.org/p/9135647/#9135912

I will also look into formalizing the `seqinfo` method in `Biostrings`. 

Thanks!
-Marcel