### PR TITLE
Fix udcFileMayOpen and udcFilesCacheFiles to handle basename with query parameters

### DIFF
--- a/src/ucsc/udc.c
+++ b/src/ucsc/udc.c
@@ -1081,6 +1081,38 @@ if (startsWith("http", protocol))
     }
 }
 
+unsigned long djb2_hash(unsigned char *str) {
+    unsigned long hash = 5381;
+    int c;
+
+    while (c = *str++)
+        hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+
+    return hash;
+}
+
+char* get_hashed_basename_path(char *afterProtocol) {
+    /*retrive basename and hash it*/
+    char *name = basename(afterProtocol);
+    unsigned long hash_id = djb2_hash((unsigned char*)name);
+
+    /* calculate size of url without basename and total buffer size*/
+    int url_size = strlen(afterProtocol) - strlen(name);
+    int total_size = url_size + sizeof(unsigned long);
+
+    /* substring afterProtocol to get url without basename*/
+    char path[url_size];
+    memcpy(path, afterProtocol, url_size);
+    path[url_size] = '\0';
+
+    /*create buffer and concat url without base and hash_id*/
+    char *full_path = malloc(total_size * sizeof(char));
+    int cx = snprintf(full_path, total_size, "%s", path);
+    snprintf(full_path + cx, total_size, "%ld", hash_id);
+
+    return full_path;
+}
+
 struct udcFile *udcFileMayOpen(char *url, char *cacheDir)
 /* Open up a cached file. cacheDir may be null in which case udcDefaultDir() will be
  * used.  Return NULL if file doesn't exist.
@@ -1153,7 +1185,8 @@ if (isTransparent)
     }
 else
     {
-    udcPathAndFileNames(file, cacheDir, protocol, afterProtocol);
+    char *full_path = get_hashed_basename_path(afterProtocol);
+    udcPathAndFileNames(file, cacheDir, protocol, full_path);
     if (!useCacheInfo)
 	{
 	file->updateTime = info.updateTime;
@@ -1205,7 +1238,8 @@ udcParseUrl(url, &protocol, &afterProtocol, &colon);
 if (colon == NULL)
     return NULL;
 AllocVar(file);
-udcPathAndFileNames(file, cacheDir, protocol, afterProtocol);
+char *full_path = get_hashed_basename_path(afterProtocol);
+udcPathAndFileNames(file, cacheDir, protocol, full_path);
 struct slName *list = NULL;
 slAddHead(&list, slNameNew(file->bitmapFileName));
 slAddHead(&list, slNameNew(file->sparseFileName));

--- a/src/ucsc/udc.c
+++ b/src/ucsc/udc.c
@@ -1098,17 +1098,16 @@ char* get_hashed_basename_path(char *afterProtocol) {
 
     /* calculate size of url without basename and total buffer size*/
     int url_size = strlen(afterProtocol) - strlen(name);
-    int total_size = url_size + sizeof(unsigned long);
+    int total_size = url_size + floor(1.0 + log10((double) llabs(hash_id))) + 1;
 
     /* substring afterProtocol to get url without basename*/
-    char path[url_size];
+    char path[url_size + 1];
     memcpy(path, afterProtocol, url_size);
     path[url_size] = '\0';
 
     /*create buffer and concat url without base and hash_id*/
-    char *full_path = malloc(total_size * sizeof(char));
-    int cx = snprintf(full_path, total_size, "%s", path);
-    snprintf(full_path + cx, total_size, "%ld", hash_id);
+    char *full_path = needMem(total_size * sizeof(char));
+    snprintf(full_path, total_size, "%s%ld", path, hash_id);
 
     return full_path;
 }
@@ -1198,6 +1197,7 @@ else
 if (udcCacheTimeout() > 0 && udcCacheEnabled() && fileExists(file->bitmapFileName))
 	    (void)maybeTouchFile(file->bitmapFileName);
 #endif
+    freeMem(full_path);
 	}
 
     if (udcCacheEnabled())
@@ -1251,6 +1251,7 @@ freeMem(file->sparseFileName);
 freeMem(file);
 freeMem(protocol);
 freeMem(afterProtocol);
+freeMem(full_path);
 return list;
 }
 


### PR DESCRIPTION
Fix #65 