### PR TITLE
Fix '\item' tags with empty labels in .Rd files

### DIFF
--- a/man/BigBedFile.Rd
+++ b/man/BigBedFile.Rd
@@ -93,8 +93,7 @@ export.bb(object, con, ...)
   information:
 
   \describe{
-    \item{}{
-      \code{seqinfo(x)}:
+    \item{\code{seqinfo(x)}:}{
       Gets the \code{\link[GenomeInfoDb]{Seqinfo}} object
       indicating the lengths of the sequences for the intervals in the
       file. No circularity or genome information is available.

--- a/man/BigBedSelection.rd
+++ b/man/BigBedSelection.rd
@@ -20,8 +20,8 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{\code{BigBedSelection(ranges = GRanges(), colnames =
-        "score")}: Constructs a \code{BigBedSelection} with the given
+    \item{\code{BigBedSelection(ranges = GRanges(), colnames =
+        "score")}:}{ Constructs a \code{BigBedSelection} with the given
         \code{ranges} and \code{colnames}.
         a \code{character} identifying a genome (see
         \code{\link{GenomicSelection}}), or a
@@ -33,7 +33,7 @@
 
 \section{Coercion}{
   \describe{
-    \item{}{\code{as(from, "BigBedSelection")}: Coerces \code{from} to a
+    \item{\code{as(from, "BigBedSelection")}:}{ Coerces \code{from} to a
       \code{BigBedSelection} object. Typically, \code{from} is a
       \code{\link[GenomicRanges]{GRanges}} or
       a \code{\link[IRanges]{IntegerRangesList}}, the ranges of

--- a/man/BigWigFile.Rd
+++ b/man/BigWigFile.Rd
@@ -134,17 +134,15 @@ export.bw(object, con, ...)
   information:
 
   \describe{
-    \item{}{
-      \code{seqinfo(x)}:
+    \item{\code{seqinfo(x)}:}{
       Gets the \code{\link[GenomeInfoDb]{Seqinfo}} object
       indicating the lengths of the sequences for the intervals in the
       file. No circularity or genome information is available.
     }
-    \item{}{
-      \code{summary(ranges = as(seqinfo(object), "GenomicRanges"), size
+    \item{\code{summary(ranges = as(seqinfo(object), "GenomicRanges"), size
         = 1L, type = c("mean", "min", "max", "coverage", "sd"),
         defaultValue = NA_real_),
-	as = c("GRangesList", "RleList", "matrix"), ...}:
+	as = c("GRangesList", "RleList", "matrix"), ...}:}{
         Aggregates the intervals in the file
         that fall into \code{ranges}, which should be something
         coercible to \code{GRanges}.  The aggregation essentially

--- a/man/BigWigSelection-class.Rd
+++ b/man/BigWigSelection-class.Rd
@@ -18,8 +18,8 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{\code{BigWigSelection(ranges = GRanges(), colnames =
-        "score")}: Constructs a \code{BigWigSelection} with the given
+    \item{\code{BigWigSelection(ranges = GRanges(), colnames =
+        "score")}:}{ Constructs a \code{BigWigSelection} with the given
         \code{ranges} and \code{colnames}. \code{ranges} can be either
         something coercible to a \code{\linkS4class{IntegerRangesList}},
         a \code{character} identifying a genome (see
@@ -32,7 +32,7 @@
 
 \section{Coercion}{
   \describe{
-    \item{}{\code{as(from, "BigWigSelection")}: Coerces \code{from} to a
+    \item{\code{as(from, "BigWigSelection")}:}{ Coerces \code{from} to a
       \code{BigWigSelection} object. Typically, \code{from} is a
       \code{\link[GenomicRanges]{GRanges}} or
       a \code{\link[IRanges]{IntegerRangesList}}, the ranges of

--- a/man/BrowserViewList-class.Rd
+++ b/man/BrowserViewList-class.Rd
@@ -16,7 +16,7 @@
 
 \section{Constructor}{
   \describe{
-  \item{}{\code{BrowserViewList(...)}: Concatenates the
+  \item{\code{BrowserViewList(...)}:}{ Concatenates the
       \code{BrowserView} objects in \code{...} into a new
       \code{BrowserViewList}.  This is rarely called by the user.
     } 

--- a/man/Chain-class.Rd
+++ b/man/Chain-class.Rd
@@ -46,25 +46,20 @@
   \code{ChainBlock} objects.
   
   \describe{
-    \item{}{
-      \code{ranges(x)}:
+    \item{\code{ranges(x)}:}{
       Get the \code{\link[IRanges]{IntegerRanges}} object holding
       the starts and ends of the "from" ranges. Each range is a
       contiguous block of positions aligned without gaps to the other
       sequence.
     }
-    \item{}{
-      \code{offset(x)}: Integer offset from the "from" start to the
+    \item{\code{offset(x)}:}{ Integer offset from the "from" start to the
       "end" start (which could be in another chromosome).
     }
-    \item{}{
-      \code{score(x)}: The score for each mapping.
+    \item{\code{score(x)}:}{ The score for each mapping.
     }
-    \item{}{
-      \code{space(x)}: The space (chromosome) of the "to" range.
+    \item{\code{space(x)}:}{ The space (chromosome) of the "to" range.
     }
-    \item{}{
-      \code{reversed(x)}: Whether the mapping inverts the region, i.e.,
+    \item{\code{reversed(x)}:}{ Whether the mapping inverts the region, i.e.,
       the alignment is between different strands.
     }
   }
@@ -80,8 +75,7 @@
   \code{exclude} argument to the \code{import} method.
   
   \describe{
-    \item{}{
-      \code{import.chain(con, exclude = "_", ...)}:
+    \item{\code{import.chain(con, exclude = "_", ...)}:}{
       Imports a chain file named \code{con} as a \code{Chain} object, a
       list of \code{ChainBlock}s. Alignments for chromosomes matching the
       \code{exclude} pattern are not imported.

--- a/man/GFFFile-class.Rd
+++ b/man/GFFFile-class.Rd
@@ -245,7 +245,7 @@ export.gff3(object, con, ...)
 
   It has the following utility methods:
   \describe{
-    \item{}{\code{genome}: Gets the genome identifier from
+    \item{\code{genome}:}{ Gets the genome identifier from
       the \dQuote{genome-build} header directive.
     }
   }

--- a/man/GenomicData.Rd
+++ b/man/GenomicData.Rd
@@ -21,13 +21,11 @@ to manipulate data on genomic ranges.}
   \code{x} is a \code{GenomicRanges} or \code{IntegerRangesList} object.
 
   \describe{
-    \item{}{
-      \code{chrom(x), chrom(x) <- value}: Gets or
+    \item{\code{chrom(x), chrom(x) <- value}:}{ Gets or
       sets the chromosome names for \code{x}. The length of \code{value}
       should equal the length of \code{x}.
     }
-    \item{}{
-      \code{score(x)}: Gets the \dQuote{score} column from the element
+    \item{\code{score(x)}:}{ Gets the \dQuote{score} column from the element
       metadata of a \code{GenomicRanges} or \code{GRangesList}. Many
       track formats have a score column, so this is often used during
       export. The \code{ANY} fallback for this method simply returns
@@ -38,9 +36,8 @@ to manipulate data on genomic ranges.}
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{GenomicData(ranges, ..., strand = NULL, chrom = NULL,
-        genome = NULL)}: Constructs a \code{GRanges} instance with
+    \item{\code{GenomicData(ranges, ..., strand = NULL, chrom = NULL,
+        genome = NULL)}:}{ Constructs a \code{GRanges} instance with
       the given \code{ranges} and variables in \code{...} (see the
       \code{\link[GenomicRanges]{GRanges}} constructor).
 

--- a/man/IntegerRangesList-methods.Rd
+++ b/man/IntegerRangesList-methods.Rd
@@ -23,8 +23,7 @@
   \code{x} is a \code{IntegerRangesList} object.
 
   \describe{
-    \item{}{
-      \code{chrom(x), chrom(x) <- value}: Gets or sets the chromosome
+    \item{\code{chrom(x), chrom(x) <- value}:}{ Gets or sets the chromosome
       names for \code{x}. This is an alias for
       \code{names(x)}.
     }

--- a/man/Quickload-class.Rd
+++ b/man/Quickload-class.Rd
@@ -33,8 +33,7 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{Quickload(uri = "quickload", create = FALSE)}: Constructs a
+    \item{\code{Quickload(uri = "quickload", create = FALSE)}:}{ Constructs a
       new \code{Quickload} object, representing a repository at
       \code{uri}. If \code{create} is \code{TRUE}, and \code{uri} is
       writeable (i.e., local), the repository is created if it does not
@@ -49,16 +48,16 @@
   object.
   
   \describe{
-    \item{}{\code{x$genome}, \code{x[["genome"]]}: Get
+    \item{\code{x$genome}, \code{x[["genome"]]}:}{ Get
       the \code{\linkS4class{QuickloadGenome}} object for the genome named
       \code{genome}. This is where all the data is stored.
     }
-    \item{}{\code{length(x)}: number of genomes in the repository
+    \item{\code{length(x)}:}{ number of genomes in the repository
     }
-    \item{}{\code{uri(x)}:
+    \item{\code{uri(x)}:}{
       Get the URI pointing to the Quickload repository.
     }
-    \item{}{\code{genome(x)}:
+    \item{\code{genome(x)}:}{
       Get the identifiers of the genomes present in the repository.
     }
   }

--- a/man/QuickloadGenome-class.Rd
+++ b/man/QuickloadGenome-class.Rd
@@ -45,10 +45,9 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{QuickloadGenome(quickload, genome, create = FALSE,
+    \item{\code{QuickloadGenome(quickload, genome, create = FALSE,
         seqinfo = seqinfo(genome),
-        title = toString(genome))}: Constructs a
+        title = toString(genome))}:}{ Constructs a
         new \code{QuickloadGenome} object, representing \code{genome} in
         the repository \code{quickload} (a URI string or a
         \code{\linkS4class{Quickload}} object).
@@ -78,30 +77,24 @@
   \code{Quickload} object.
   
   \describe{
-    \item{}{
-      \code{seqinfo(x)}, \code{seqinfo(x) <- value}: Gets or sets the
+    \item{\code{seqinfo(x)}, \code{seqinfo(x) <- value}:}{ Gets or sets the
       \code{\link[GenomeInfoDb]{Seqinfo}} object indicating the lengths
       of the sequences in the genome. No circularity information or genome
       identifier is stored.
     }
-    \item{}{
-      \code{quickload(x)}: Get the Quickload object that contains this
+    \item{\code{quickload(x)}:}{ Get the Quickload object that contains this
       genome.
     }
-    \item{}{
-      \code{uri(x)}: Get the uri pointing to the genome directory in the
+    \item{\code{uri(x)}:}{ Get the uri pointing to the genome directory in the
       Quickload repository
     }
-    \item{}{
-      \code{genome(x)}: Get the name of the genome, e.g.
+    \item{\code{genome(x)}:}{ Get the name of the genome, e.g.
       \dQuote{H_sapiens_Feb_2009}.
     }
-    \item{}{
-      \code{releaseDate(x)}: Get the release portion of the genome name,
+    \item{\code{releaseDate(x)}:}{ Get the release portion of the genome name,
       e.g., \dQuote{Feb_2009}.
     }
-    \item{}{
-      \code{organism(object)}: Get the organism portion of the genome name,
+    \item{\code{organism(object)}:}{ Get the organism portion of the genome name,
       e.g., \dQuote{H sapiens}.
     }
   }
@@ -109,21 +102,16 @@
 
 \section{Data Access}{
   \describe{
-    \item{}{
-      \code{length(x)}: number of datasets
+    \item{\code{length(x)}:}{ number of datasets
     }
-    \item{}{
-      \code{names(x), trackNames(x)}: names of the datasets
+    \item{\code{names(x), trackNames(x)}:}{ names of the datasets
     }
-    \item{}{
-      \code{mcols(x)}: merged metadata on the datasets
+    \item{\code{mcols(x)}:}{ merged metadata on the datasets
     }
-    \item{}{
-      \code{track(x, name), x$name}: get the track called \code{name}
+    \item{\code{track(x, name), x$name}:}{ get the track called \code{name}
     }
-    \item{}{
-      \code{track(x, name, format = bestFileFormat(value), ...) <-
-        value, x$name <- value}: store the track \code{value} under
+    \item{\code{track(x, name, format = bestFileFormat(value), ...) <-
+        value, x$name <- value}:}{ store the track \code{value} under
         \code{name}. Note that track storing is only supported
         for local repositories, i.e., those with a \code{file://} URI
         scheme.
@@ -148,12 +136,10 @@
         interpretation is up to the client. IGB supports an ever-growing
         list; please see its documentation.
     }
-    \item{}{
-      \code{referenceSequence(x)}: Get the reference sequence, as a
+    \item{\code{referenceSequence(x)}:}{ Get the reference sequence, as a
       \code{DNAStringSet}.
     }
-    \item{}{
-      \code{referenceSequence(x) <- value}: Set the reference sequence, as a
+    \item{\code{referenceSequence(x) <- value}:}{ Set the reference sequence, as a
       \code{DNAStringSet}. It is written as a 2bit file. This only works
       on local repositories.
     }

--- a/man/TrackDb-class.Rd
+++ b/man/TrackDb-class.Rd
@@ -27,22 +27,17 @@
   Every implementation should support these methods:
   
   \describe{
-    \item{}{
-      \code{length(x)}: number of tracks
+    \item{\code{length(x)}:}{ number of tracks
     }
-    \item{}{
-      \code{names(x)}, \code{trackNames(x)}: names of the tracks
+    \item{\code{names(x)}, \code{trackNames(x)}:}{ names of the tracks
     }
-    \item{}{
-      \code{mcols(x)}: merged metadata on the tracks
+    \item{\code{mcols(x)}:}{ merged metadata on the tracks
     }
-    \item{}{
-      \code{track(x, name)}, \code{x$name}, \code{x[[name]]}:
+    \item{\code{track(x, name)}, \code{x$name}, \code{x[[name]]}:}{
       get the track called \code{name}
     }
-    \item{}{
-      \code{track(x, name) <- value}, \code{x$name <- value},
-      \code{x[[name]] <- value}: store the track \code{value} under
+    \item{\code{track(x, name) <- value}, \code{x$name <- value},
+      \code{x[[name]] <- value}:}{ store the track \code{value} under
       \code{name}. Different implementations will support different
       types for \code{value}. Generally, an interval data structure like
       \code{GenomicRanges}.

--- a/man/TrackHub-class.Rd
+++ b/man/TrackHub-class.Rd
@@ -53,8 +53,7 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{TrackHub(uri, create = FALSE)}: Constructs a
+    \item{\code{TrackHub(uri, create = FALSE)}:}{ Constructs a
       new \code{TrackHub} object, representing a repository at
       \code{uri}. If \code{create} is \code{TRUE}, and \code{uri} is
       writeable (i.e., local), the repository is created if it does not
@@ -69,19 +68,19 @@
   object.
 
   \describe{
-    \item{}{\code{x$genome}, \code{x[["genome"]]}: Get
+    \item{\code{x$genome}, \code{x[["genome"]]}:}{ Get
       the \code{\linkS4class{TrackHubGenome}} object for the genome named
       \code{genome}.
     }
-    \item{}{\code{length(x)}: number of genomes in the repository.
+    \item{\code{length(x)}:}{ number of genomes in the repository.
     }
-    \item{}{\code{uri(x)}:
+    \item{\code{uri(x)}:}{
       Get the URI pointing to the TrackHub repository.
     }
-    \item{}{\code{genome(x)}:
+    \item{\code{genome(x)}:}{
       Get the identifiers of the genomes present in the repository.
     }
-    \item{}{\code{writeTrackHub(x)}:
+    \item{\code{writeTrackHub(x)}:}{
       Write hub content and genomes from memory representation to the hub file and genomes file.
       It also create resources if they are missing like genomes file and genome directory for
       newly add genome.
@@ -92,53 +91,37 @@
 \section{Data Access}{
   Note that all storing methods(like \code{hub()<-}) are only supported for local repositories, i.e., those with a file:// URI scheme.
   \describe{
-    \item{}{
-      \code{hub(x)}: get the value of hub.
+    \item{\code{hub(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{hub(x) <- value}: store the \code{value} of hub for \code{x}.
+    \item{\code{hub(x) <- value}:}{ store the \code{value} of hub for \code{x}.
     }
-    \item{}{
-      \code{shortLabel(x)}: get the value of hub.
+    \item{\code{shortLabel(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{shortLabel(x) <- value}: store the \code{value} of shortLabel for \code{x}.
+    \item{\code{shortLabel(x) <- value}:}{ store the \code{value} of shortLabel for \code{x}.
     }
-    \item{}{
-      \code{longLabel(x)}: get the value of hub.
+    \item{\code{longLabel(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{longLabel(x) <- value}: store the \code{value} of longLabel for \code{x}.
+    \item{\code{longLabel(x) <- value}:}{ store the \code{value} of longLabel for \code{x}.
     }
-    \item{}{
-      \code{genomeFile(x)}: get the value of hub.
+    \item{\code{genomeFile(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{genomeFile(x) <- value}: store the \code{value} of genomesFile for \code{x}.
+    \item{\code{genomeFile(x) <- value}:}{ store the \code{value} of genomesFile for \code{x}.
     }
-    \item{}{
-      \code{email(x)}: get the value of hub.
+    \item{\code{email(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{email(x) <- value}: store the \code{value} of email for \code{x}.
+    \item{\code{email(x) <- value}:}{ store the \code{value} of email for \code{x}.
     }
-    \item{}{
-      \code{descriptionUrl(x)}: get the value of hub.
+    \item{\code{descriptionUrl(x)}:}{ get the value of hub.
     }
-    \item{}{
-      \code{descriptionUrl(x) <- value}: store the \code{value} of descriptionUrl for \code{x}.
+    \item{\code{descriptionUrl(x) <- value}:}{ store the \code{value} of descriptionUrl for \code{x}.
     }
-    \item{}{
-      \code{genomeField(x, name, field)}: Get the \code{value} of \code{field} for \code{name} genome.
+    \item{\code{genomeField(x, name, field)}:}{ Get the \code{value} of \code{field} for \code{name} genome.
     }
-    \item{}{
-      \code{genomeField(x, name, field) <- value}: Set or Update the \code{field} and \code{value} for \code{name} genome.
+    \item{\code{genomeField(x, name, field) <- value}:}{ Set or Update the \code{field} and \code{value} for \code{name} genome.
     }
-    \item{}{
-      \code{genomeInfo(x, name)}: Get the \code{Genome} object for \code{name} genome.
+    \item{\code{genomeInfo(x, name)}:}{ Get the \code{Genome} object for \code{name} genome.
     }
-    \item{}{
-      \code{genomeInfo(x) <- value}: Add \code{value} (Genome object) to existing genomes list.
+    \item{\code{genomeInfo(x) <- value}:}{ Add \code{value} (Genome object) to existing genomes list.
       \code{Genome} takes named arguemnts of all UCSC supported fields for genome
       file(like \code{genome, trackDb, twoBitPath}, etc).
     }

--- a/man/TrackHubGenome-class.Rd
+++ b/man/TrackHubGenome-class.Rd
@@ -42,8 +42,7 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{TrackHubGenome(trackhub, genome, create = FALSE}: Constructs a
+    \item{\code{TrackHubGenome(trackhub, genome, create = FALSE}:}{ Constructs a
         new \code{TrackHubGenome} object, representing \code{genome} in
         the repository \code{trackhub} (a URI string or a
         \code{\linkS4class{TrackHub}} object).
@@ -64,38 +63,29 @@
   In the code snippets below, \code{x} represent a \code{TrackHubGenome} object.
 
   \describe{
-    \item{}{
-      \code{uri(x)}: Get the uri pointing to the genome directory in the
+    \item{\code{uri(x)}:}{ Get the uri pointing to the genome directory in the
       TrackHub repository.
     }
-    \item{}{
-      \code{genome(x)}: Get the name of the genome, e.g.
+    \item{\code{genome(x)}:}{ Get the name of the genome, e.g.
       \dQuote{hg19}.
     }
-    \item{}{
-      \code{length(x)}: number of tracks
+    \item{\code{length(x)}:}{ number of tracks
     }
-    \item{}{
-      \code{names(x), trackNames(x)}: names of the tracks
+    \item{\code{names(x), trackNames(x)}:}{ names of the tracks
     }
-    \item{}{
-      \code{getTracks(x)}: Get the \code{List} of \code{Track} from the tracks
+    \item{\code{getTracks(x)}:}{ Get the \code{List} of \code{Track} from the tracks
     }
-    \item{}{
-      \code{trackhub(x)}: Get the TrackHub object that contains this
+    \item{\code{trackhub(x)}:}{ Get the TrackHub object that contains this
       genome.
     }
-    \item{}{
-      \code{organism(x)}: Get the organism name for this genome,
+    \item{\code{organism(x)}:}{ Get the organism name for this genome,
       e.g., \dQuote{H sapiens}.
     }
-    \item{}{
-      \code{trackField(x, name, field)}: Get the \code{value} of \code{field} for \code{name} track.
+    \item{\code{trackField(x, name, field)}:}{ Get the \code{value} of \code{field} for \code{name} track.
     }
-    \item{}{
-      \code{trackField(x, name, field) <- value}: Store the \code{field} and \code{value} for \code{name} track.
+    \item{\code{trackField(x, name, field) <- value}:}{ Store the \code{field} and \code{value} for \code{name} track.
     }
-    \item{}{\code{writeTrackHub(x)}:
+    \item{\code{writeTrackHub(x)}:}{
       Write tracks from memory representation to the trackDb file.
     }
   }
@@ -103,12 +93,10 @@
 
 \section{Data Access}{
   \describe{
-    \item{}{
-      \code{track(x, name), x$name}: get the track called \code{name}
+    \item{\code{track(x, name), x$name}:}{ get the track called \code{name}
     }
-    \item{}{
-      \code{track(x, name, format = bestFileFormat(value)) <-
-        value, x$name <- value}: store the track \code{value} under
+    \item{\code{track(x, name, format = bestFileFormat(value)) <-
+        value, x$name <- value}:}{ store the track \code{value} under
         \code{name}. Note that track storing is only supported
         for local repositories, i.e., those with a \code{file://} URI
         scheme.
@@ -126,12 +114,10 @@
         type of track line. For \code{RsamtoolsFile} objects, the file
         and its index are copied.
     }
-    \item{}{
-      \code{referenceSequence(x)}: Get the reference sequence, as a
+    \item{\code{referenceSequence(x)}:}{ Get the reference sequence, as a
       \code{DNAStringSet}.
     }
-    \item{}{
-      \code{referenceSequence(x) <- value}: Set the reference sequence, as a
+    \item{\code{referenceSequence(x) <- value}:}{ Set the reference sequence, as a
       \code{DNAStringSet}. It is written as a 2bit file. This only works
       on local repositories.
     }

--- a/man/TwoBitFile-class.Rd
+++ b/man/TwoBitFile-class.Rd
@@ -103,8 +103,7 @@ export.2bit(object, con, ...)
   A TwoBit file embeds the sequence information, which can be retrieved
   with the following:
   \describe{
-    \item{}{
-      \code{seqinfo(x)}:
+    \item{\code{seqinfo(x)}:}{
       Gets the \code{\link[GenomeInfoDb]{Seqinfo}} object indicating
       the lengths of the sequences for the intervals in the
       file. No circularity or genome information is available.

--- a/man/UCSCSchema-class.Rd
+++ b/man/UCSCSchema-class.Rd
@@ -22,9 +22,9 @@
   \code{UCSCSchema} object.
 
   \describe{
-    \item{}{\code{genome(x)}: Get the genome for the table. }
-    \item{}{\code{tableName(x)}: Get the name of the table. }
-    \item{}{\code{nrow(x)}: Get the number of rows in the table. }
+    \item{\code{genome(x)}:}{ Get the genome for the table. }
+    \item{\code{tableName(x)}:}{ Get the name of the table. }
+    \item{\code{nrow(x)}:}{ Get the number of rows in the table. }
   }
 }
 

--- a/man/UCSCTableQuery-class.Rd
+++ b/man/UCSCTableQuery-class.Rd
@@ -89,9 +89,8 @@
 
 \section{Constructor}{
   \describe{
-    \item{}{
-      \code{ucscTableQuery(x, range = seqinfo(x), table = NULL,
-        names = NULL, hubUrl = NULL, genome = NULL)}: Creates a \code{UCSCTableQuery} with the
+    \item{\code{ucscTableQuery(x, range = seqinfo(x), table = NULL,
+        names = NULL, hubUrl = NULL, genome = NULL)}:}{ Creates a \code{UCSCTableQuery} with the
         \code{UCSCSession}, genome identifier or TrackHub URI given as \code{x} and
         the table name given by the single string \code{table}. \code{range} should
         be a genome string identifier, a \code{GRanges} instance or
@@ -107,21 +106,18 @@
   Below, \code{object} is a \code{UCSCTableQuery} instance.
   
   \describe{
-    \item{}{
-      \code{track(object)}:
+    \item{\code{track(object)}:}{
       Retrieves the indicated table as a track, i.e. a \code{GRanges}
       object. Note that not all tables are available as tracks.
     }
-    \item{}{
-      \code{getTable(object)}: Retrieves the indicated table as a
+    \item{\code{getTable(object)}:}{ Retrieves the indicated table as a
       \code{data.frame}. Note that not all tables are output in
       parseable form, and that UCSC will truncate responses if they
       exceed certain limits (usually around 100,000 records). The safest
       (and most efficient) bet for large queries is to download the file
       via FTP and query it locally.
     }
-    \item{}{
-      \code{tableNames(object)}: Gets the names of the tables available
+    \item{\code{tableNames(object)}:}{ Gets the names of the tables available
       for the provider, table and range specified by the query.
     }
   }
@@ -132,31 +128,31 @@
   \code{UCSCTableQuery} object.
 
   \describe{
-    \item{}{\code{genome(x)}, \code{genome(x) <- value}: Gets or sets
+    \item{\code{genome(x)}, \code{genome(x) <- value}:}{ Gets or sets
     the genome identifier (e.g. \dQuote{hg18}) of the object.
     }
-    \item{}{\code{hubUrl(x)}, \code{hubUrl(x) <- value}: Gets or sets
+    \item{\code{hubUrl(x)}, \code{hubUrl(x) <- value}:}{ Gets or sets
     the TrackHub URI.
     }
-    \item{}{\code{tableName(x)}, \code{tableName(x) <- value}: Get or
+    \item{\code{tableName(x)}, \code{tableName(x) <- value}:}{ Get or
       set the single string indicating the name of the table to
       retrieve. May be \code{NULL}, in which case the table is
       automatically determined.
     }
-    \item{}{\code{range(x)}, \code{range(x) <- value}: Get or set the
+    \item{\code{range(x)}, \code{range(x) <- value}:}{ Get or set the
       \code{GRanges} indicating the portion of the table to retrieve in
       genomic coordinates. Any missing information, such as the genome
       identifier, is filled in using \code{range(browserSession(x))}. It
       is also possible to set the genome identifier string or
       a \code{IntegerRangesList}.
     }
-    \item{}{\code{names(x)}, \code{names(x) <- value}: Get or set the
+    \item{\code{names(x)}, \code{names(x) <- value}:}{ Get or set the
       names of the features to retrieve. If \code{NULL}, this filter is
       disabled.
     }
-    \item{}{\code{ucscSchema(x)}: Get
+    \item{\code{ucscSchema(x)}:}{ Get
       the \code{\linkS4class{UCSCSchema}} object describing the selected table.}
-    \item{}{\code{ucscTables(genome, track)}: Get the list of tables for the 
+    \item{\code{ucscTables(genome, track)}:}{ Get the list of tables for the 
       specified track(e.g. \dQuote{Assembly}) and genome identifier (e.g. \dQuote{hg19}).
       Here \code{genome} and \code{track} must be a single non-NA string.
     }

--- a/man/targets.Rd
+++ b/man/targets.Rd
@@ -32,4 +32,3 @@ targetTrack <- with(targets,
                 strand = strand, chrom = chrom))
 }
 \keyword{datasets}
-

--- a/man/ucscSession-class.Rd
+++ b/man/ucscSession-class.Rd
@@ -97,9 +97,8 @@ Class \code{"\linkS4class{BrowserSession}"}, directly.
       the \code{table} parameter. See \code{\link{tableNames}} for a way
       to list the available tables.
     }
-    \item{}{
-      \code{getTable(object, name, range = base::range(object), table =
-      NULL)}: Retrieves the table indicated by the track \code{name} and
+    \item{\code{getTable(object, name, range = base::range(object), table =
+      NULL)}:}{ Retrieves the table indicated by the track \code{name} and
       \code{table} name, over \code{range}, as a \code{data.frame}. See
       \code{\link{getTable}}.
     }


### PR DESCRIPTION
A few months ago `R CMD check` started to complain about these tags, by issuing the _\item in \describe must have non-empty label_ warning. This commit fixes the faulty tags by replacing the 96 occurences of `\item{}{\code{...}: ...}` with `\item{\code{...}:}{ ...}`.

The substitutions were made by calling `fix_items_in_rdfiles()` (from the [**fixRdItems**](https://github.com/hpages/fixRdItems) package) on the `man/` folder.