### PR TITLE
Switch from HTTP to HTTPS for requests to *.ucsc.edu

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rtracklayer
 Title: R interface to genome annotation files and the UCSC genome browser
-Version: 1.61.1
+Version: 1.61.2
 Author: Michael Lawrence, Vince Carey, Robert Gentleman
 Depends: R (>= 3.3), methods, GenomicRanges (>= 1.37.2)
 Imports: XML (>= 1.98-0), BiocGenerics (>= 0.35.3),

--- a/R/readGFF.R
+++ b/R/readGFF.R
@@ -9,7 +9,7 @@
         return(XVector:::open_input_files(filepath)[[1L]])
     if (!inherits(filepath, "connection"))
         stop(wmsg("'filepath' must be a single string or a connection"))
-    if (!isSeekable(filepath))
+    if (!base::isSeekable(filepath))
         stop(wmsg("connection is not seekable"))
     filepath
 }
@@ -23,14 +23,14 @@ readGFFPragmas <- function(filepath)
 {
     filexp <- .make_filexp_from_filepath(filepath)
     if (inherits(filexp, "connection")) {
-        if (!isOpen(filexp)) {
-            open(filexp)
-            on.exit(close(filexp))
+        if (!base::isOpen(filexp)) {
+            base::open(filexp)
+            on.exit(base::close(filexp))
         }
-        if (seek(filexp) != 0) {
+        if (base::seek(filexp) != 0) {
             warning(wmsg("connection is not positioned at the start ",
                          "of the file, rewinding it"), immediate.=TRUE)
-            seek(filexp, where=0)
+            base::seek(filexp, where=0)
         }
     }
     .Call(read_gff_pragmas, filexp)
@@ -267,14 +267,14 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
     ## Check 'filepath'.
     filexp <- .make_filexp_from_filepath(filepath)
     if (inherits(filexp, "connection")) {
-        if (!isOpen(filexp)) {
-            open(filexp)
-            on.exit(close(filexp))
+        if (!base::isOpen(filexp)) {
+            base::open(filexp)
+            on.exit(base::close(filexp))
         }
-        if (seek(filexp) != 0) {
+        if (base::seek(filexp) != 0) {
             warning(wmsg("connection is not positioned at the start ",
                          "of the file, rewinding it"), immediate.=TRUE)
-            seek(filexp, where=0)
+            base::seek(filexp, where=0)
         }
     }
 
@@ -286,7 +286,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
 
     ## Rewind file.
     if (inherits(filexp, "connection")) {
-        seek(filexp, where=0)
+        base::seek(filexp, where=0)
     } else {
         XVector:::rewind_filexp(filexp)
     }
@@ -323,7 +323,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
 
     ## Rewind file.
     if (inherits(filexp, "connection")) {
-        seek(filexp, where=0)
+        base::seek(filexp, where=0)
     } else {
         XVector:::rewind_filexp(filexp)
     }
@@ -396,7 +396,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
 .parseSequenceRegionsAsSeqinfo <- function(lines) {
     sr <- grep("##sequence-region", lines, value=TRUE)
     srcon <- file()
-    on.exit(close(srcon))
+    on.exit(base::close(srcon))
     writeLines(sr, srcon)
     srt <- read.table(srcon, comment.char="",
                       colClasses=list(NULL, "character", "integer",

--- a/R/readGFF.R
+++ b/R/readGFF.R
@@ -7,7 +7,7 @@
 {
     if (isSingleString(filepath))
         return(XVector:::open_input_files(filepath)[[1L]])
-    if (!is(filepath, "BiocGenerics::connection"))
+    if (!inherits(filepath, "connection"))
         stop(wmsg("'filepath' must be a single string or a connection"))
     if (!isSeekable(filepath))
         stop(wmsg("connection is not seekable"))
@@ -22,7 +22,7 @@
 readGFFPragmas <- function(filepath)
 {
     filexp <- .make_filexp_from_filepath(filepath)
-    if (is(filexp, "BiocGenerics::connection")) {
+    if (inherits(filexp, "connection")) {
         if (!isOpen(filexp)) {
             open(filexp)
             on.exit(close(filexp))
@@ -266,7 +266,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
 {
     ## Check 'filepath'.
     filexp <- .make_filexp_from_filepath(filepath)
-    if (is(filexp, "BiocGenerics::connection")) {
+    if (inherits(filexp, "connection")) {
         if (!isOpen(filexp)) {
             open(filexp)
             on.exit(close(filexp))
@@ -285,7 +285,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
     pragmas <- .Call(read_gff_pragmas, filexp)
 
     ## Rewind file.
-    if (is(filexp, "BiocGenerics::connection")) {
+    if (inherits(filexp, "connection")) {
         seek(filexp, where=0)
     } else {
         XVector:::rewind_filexp(filexp)
@@ -322,7 +322,7 @@ readGFF <- function(filepath, version=0, columns=NULL, tags=NULL,
     nrows <- scan_ans[[2L]]
 
     ## Rewind file.
-    if (is(filexp, "BiocGenerics::connection")) {
+    if (inherits(filexp, "connection")) {
         seek(filexp, where=0)
     } else {
         XVector:::rewind_filexp(filexp)

--- a/R/ucsc.R
+++ b/R/ucsc.R
@@ -8,7 +8,7 @@ setClass("UCSCSession",
 
 # gets an 'hgsid' to initialize the session
 setMethod("initialize", "UCSCSession",
-          function(.Object, url = "http://genome.ucsc.edu/cgi-bin/",
+          function(.Object, url = "https://genome.ucsc.edu/cgi-bin/",
                    user = NULL, session = NULL, force = FALSE, ...)
           {
             .Object@url <- url
@@ -300,7 +300,7 @@ normArgTrack <- function(name, trackids) {
 setMethod("ucscTableQuery", "character",
           function(x, track = NULL, range =  NULL, table = NULL,
                    names = NULL, intersectTrack = NULL, check = TRUE, hubUrl = NULL,
-                   genome = NULL, url = "http://genome.ucsc.edu/cgi-bin/") {
+                   genome = NULL, url = "https://genome.ucsc.edu/cgi-bin/") {
               stopifnot(isSingleString(x))
               if (!is.null(intersectTrack))
                 stop("intersectTrack is no longer supported")
@@ -361,7 +361,7 @@ setReplaceMethod("hubUrl", "UCSCTableQuery", function(x, value) {
 
 ## gets the track names available from the table browser
 ucscTableTracks <- function(genome) {
-  doc <- httpGet("http://genome-euro.ucsc.edu/cgi-bin/hgTables", c(db = genome, hgta_group = "allTracks"))
+  doc <- httpGet("https://genome-euro.ucsc.edu/cgi-bin/hgTables", c(db = genome, hgta_group = "allTracks"))
   label_path <- "//select[@name = 'hgta_track']/option/text()"
   labels <- sub("\n.*$", "", sapply(getNodeSet(doc, label_path), xmlValue))
   track_path <- "//select[@name = 'hgta_track']/option/@value"
@@ -1485,7 +1485,7 @@ setMethod("ucscTrackModes", "ucscTracks",
 ucscGenomes <- function(organism=FALSE) {
   stopifnot(isTRUEorFALSE(organism))
   names <- c("db", "species", "date", "name", "organism")
-  url <- RestUri("http://api.genome.ucsc.edu/")
+  url <- RestUri("https://api.genome.ucsc.edu/")
   response <- read(url$list$ucscGenomes)
   genomes <- response[[5]]
   genomeNames <- names(genomes)

--- a/R/ucsc.R
+++ b/R/ucsc.R
@@ -17,7 +17,8 @@ setMethod("initialize", "UCSCSession",
             gw <- httpGet(gwURL, cookiefile = tempfile(), header = TRUE,
                           .parse=FALSE, ...)
             if (grepl("redirectTd", gw)) {
-                url <- sub(".*?a href=\"h([^[:space:]]+cgi-bin/).*", "h\\1", gw)
+                url <- sub(".*?a href=\"http([^[:space:]]+cgi-bin/).*",
+                           "https\\1", gw)
                 return(initialize(.Object, url, user=user, session=session,
                                   force=TRUE, ...))
             }

--- a/inst/unitTests/test_bed.R
+++ b/inst/unitTests/test_bed.R
@@ -266,7 +266,7 @@ test_extendedBed <- function()
 
         # the narrowPeak format represents a variety of "BED6+N" formats
         # used by the ENCODE project.  see
-        # http://genome.ucsc.edu/FAQ/FAQformat.html
+        # https://genome.ucsc.edu/FAQ/FAQformat.html
         # "This format is used to provide called peaks of signal
         #  enrichment based on pooled, normalized (interpreted) data.
         #  It is a BED6+4 format."

--- a/man/BEDFile-class.Rd
+++ b/man/BEDFile-class.Rd
@@ -276,7 +276,7 @@ export.bedGraph(object, con, ...)
 \author{Michael Lawrence}
 
 \references{
-  \url{http://genome.ucsc.edu/goldenPath/help/customTrack.html}
+  \url{https://genome.ucsc.edu/goldenPath/help/customTrack.html}
   \url{http://bedtools.readthedocs.org/en/latest/content/general-usage.html}
 }
 

--- a/man/Bed15TrackLine-class.Rd
+++ b/man/Bed15TrackLine-class.Rd
@@ -44,7 +44,7 @@
   }
 }
 \references{ Official documentation:
-  \url{http://genomewiki.ucsc.edu/index.php/Microarray_track}. }
+  \url{https://genomewiki.ucsc.edu/index.php/Microarray_track}. }
 \author{ Michael Lawrence }
 \seealso{
   \code{\link{export.bed15}} for exporting bed15 tracks.

--- a/man/UCSCFile-class.Rd
+++ b/man/UCSCFile-class.Rd
@@ -159,7 +159,7 @@ export.ucsc(object, con, ...)
 \author{Michael Lawrence}
 
 \references{
-  \url{http://genome.ucsc.edu/goldenPath/help/customTrack.html}
+  \url{https://genome.ucsc.edu/goldenPath/help/customTrack.html}
 }
 
 \keyword{methods}

--- a/man/WIGFile-class.Rd
+++ b/man/WIGFile-class.Rd
@@ -134,7 +134,7 @@ export.wig(object, con, ...)
 \author{Michael Lawrence}
 
 \references{
-  \url{http://genome.ucsc.edu/goldenPath/help/wiggle.html}
+  \url{https://genome.ucsc.edu/goldenPath/help/wiggle.html}
 }
 
 \examples{

--- a/man/basicTrackLine-class.Rd
+++ b/man/basicTrackLine-class.Rd
@@ -59,7 +59,7 @@ Class \code{"\linkS4class{TrackLine}"}, directly.
   }
 }
 \references{
-  \url{http://genome.ucsc.edu/goldenPath/help/customTrack.html#TRACK}
+  \url{https://genome.ucsc.edu/goldenPath/help/customTrack.html#TRACK}
   for the official documentation. }
 \author{ Michael Lawrence }
 

--- a/man/liftOver.Rd
+++ b/man/liftOver.Rd
@@ -36,7 +36,7 @@ liftOver(x, chain, ...)
   from the corresponding element in the input (may be one-to-many).
 }
 \references{
-  \url{http://genome.ucsc.edu/cgi-bin/hgLiftOver}
+  \url{https://genome.ucsc.edu/cgi-bin/hgLiftOver}
 }
 \examples{
 \dontrun{

--- a/man/ucscGenomes.Rd
+++ b/man/ucscGenomes.Rd
@@ -23,7 +23,7 @@ ucscGenomes(organism=FALSE)
   genome.}
 \details{
   For populating the organism column, the web url
-  \url{http://genome.ucsc.edu/cgi-bin} is scraped for every assembly
+  \url{https://genome.ucsc.edu/cgi-bin} is scraped for every assembly
   version to get the scientific name.
 }
 \examples{

--- a/man/ucscSession-class.Rd
+++ b/man/ucscSession-class.Rd
@@ -21,7 +21,7 @@
 \section{Objects from the Class}{
   Objects can be created by calls of the form
   \code{\link{browserSession}("ucsc", url =
-    "http://genome.ucsc.edu/cgi-bin", ...)}. The arguments in \code{...}
+    "https://genome.ucsc.edu/cgi-bin", ...)}. The arguments in \code{...}
   correspond to libcurl options, see
   \code{\link[RCurl]{getCurlHandle}}. Setting these options may be
   useful e.g. for getting past a proxy.

--- a/man/ucscTrackLine-class.Rd
+++ b/man/ucscTrackLine-class.Rd
@@ -41,7 +41,7 @@
   }
 }
 \references{
-  \url{http://genome.ucsc.edu/goldenPath/help/customTrack.html#TRACK}
+  \url{https://genome.ucsc.edu/goldenPath/help/customTrack.html#TRACK}
   for the official documentation. }
 \author{ Michael Lawrence }
 

--- a/man/wigTrackLine-class.Rd
+++ b/man/wigTrackLine-class.Rd
@@ -69,7 +69,7 @@
   }
 }
 \references{ Official documentation:
-  \url{http://genome.ucsc.edu/goldenPath/help/wiggle.html}. }
+  \url{https://genome.ucsc.edu/goldenPath/help/wiggle.html}. }
 \author{ Michael Lawrence }
 \seealso{
   \code{\link{export.wig}}, \code{\link{export.bedGraph}} for exporting

--- a/vignettes/rtracklayer.Rnw
+++ b/vignettes/rtracklayer.Rnw
@@ -644,7 +644,7 @@ region of the motif.
 \Rclass{rtracklayer} can be used to download annotation tracks from
 the UCSC table browser, thus providing a convenient programmatic
 alternative to the web interface available at
-\url{http://genome.ucsc.edu/cgi-bin/hgTables}.  
+\url{https://genome.ucsc.edu/cgi-bin/hgTables}.
 
 \textbf{Note} that not all tables are output in parseable form, and
 that \textbf{UCSC will truncate responses} if they exceed certain
@@ -668,7 +668,7 @@ tbl.rmsk <- getTable(
 There are several important points to understand about this example:
 \begin{enumerate}
 \item The \Rcode{ucscTableQuery} used above is a proxy for, and provides communication with,
-  the remote UCSC table browser (see \url{http://genome.ucsc.edu/cgi-bin/hgTables}).
+  the remote UCSC table browser (see \url{https://genome.ucsc.edu/cgi-bin/hgTables}).
 \item You must know the name of the track and table (or sub-track) that you want.  The 
   way to do this is explained in detail below, in section 5.3.
 \item If the track contains multiple tables (which is the case for 
@@ -709,7 +709,7 @@ tbl.k562.dgf.hg19 <- getTable(ucscTableQuery (mySession, track=track.name,
   
 As the examples above demonstrate, you must know the exact UCSC-style name for
 the track and table you wish to download.  You may browse these interactively at
-\url{http://genome.ucsc.edu/cgi-bin/hgTables?org=Human&db=hg19} or
+\url{https://genome.ucsc.edu/cgi-bin/hgTables?org=Human&db=hg19} or
 programmatically, as we demonstrate here.
 
 <<trackAndTableNameDiscovery, eval=FALSE>>=


### PR DESCRIPTION
- Fix #95.
- Also fix regression in `readGFF()` introduced by PR #79, and addresses the original issue.
- Version bumped to 1.61.2

**rtracklayer** 1.61.2 successfully passed `R CMD build` and `R CMD check` on my laptop (Ubuntu 23.10), nebbiolo2 (Ubuntu 22.04.3 LTS), lconway (Intel macOS 12.6.5 Monterey), and kjohnson1 (arm64 macOS 13.3.1 Ventura). I don't have access to a Windows machine to test at the moment but hopefully everything is fine there too.