### PR TITLE
fix unknown track error in line665: rmsk --> RepeatMasker

### DIFF
--- a/vignettes/rtracklayer.Rnw
+++ b/vignettes/rtracklayer.Rnw
@@ -658,11 +658,11 @@ This simple example identifies repeat-masked regions in and around the transcrip
 of the human E2F3 gene, in hg19:
 <<rmsk.e2f3, eval=FALSE>>=
 library (rtracklayer)
-mySession = browserSession("UCSC")
+mySession <- browserSession("UCSC")
 genome(mySession) <- "hg19"
 e2f3.tss.grange <- GRanges("chr6", IRanges(20400587, 20403336))
 tbl.rmsk <- getTable(
-   ucscTableQuery(mySession, track="rmsk", 
+   ucscTableQuery(mySession, track="RepeatMasker", 
                    range=e2f3.tss.grange, table="rmsk"))
 @ 
 There are several important points to understand about this example:


### PR DESCRIPTION
I am happy to see there is a demonstration of usage to get the RepeatMakser track in rtracklayer, since I am very interested in this field. I just found an unknown track error. Please consider accepting this change in the tutorial. Thanks a lot!

Details:
This function demonstration wants to get the RepeatMasker table from UCSC. Thus, the track needs to be RepeatMasker instead of rmsk. Otherwise, it will get an unknown track error in R: 

Error in h(simpleError(msg, call)) : 
error in evaluating the argument 'object' in selecting a method for function 'getTable': error in evaluating the argument 'table' in selecting a method for function '%in%': Unknown track: rmsk