### PR TITLE
Use curl::curl_unescape() instead of utils::URLdecode()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: rtracklayer
 Title: R interface to genome annotation files and the UCSC genome browser
-Version: 1.63.1
+Version: 1.63.2
 Author: Michael Lawrence, Vince Carey, Robert Gentleman
 Depends: R (>= 3.3), methods, GenomicRanges (>= 1.37.2)
 Imports: XML (>= 1.98-0), BiocGenerics (>= 0.35.3),
          S4Vectors (>= 0.23.18), IRanges (>= 2.13.13), XVector (>= 0.19.7),
          GenomeInfoDb (>= 1.15.2),
-         Biostrings (>= 2.47.6), zlibbioc, httr,
+         Biostrings (>= 2.47.6), zlibbioc, curl, httr,
          Rsamtools (>= 1.31.2), GenomicAlignments (>= 1.15.6), BiocIO, tools,
 	 restfulr (>= 0.0.13)
 Suggests: BSgenome (>= 1.33.4), humanStemCell, microRNA (>= 1.1.1), genefilter,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,7 +13,7 @@ import(zlibbioc)
 ###
 
 importFrom("stats", offset, setNames)
-importFrom("utils", count.fields, URLdecode, URLencode, browseURL,
+importFrom("utils", count.fields, URLencode, browseURL,
            download.file, read.table, read.csv, type.convert, write.table,
            packageVersion, strcapture)
 importFrom("tools", file_path_as_absolute, file_ext, file_path_sans_ext)
@@ -27,6 +27,8 @@ importFrom("XML", getNodeSet, xmlValue, xmlAttrs, htmlTreeParse, xmlTreeParse,
            xmlInternalTreeParse, parseURI, newXMLNode, xmlChildren,
            addChildren, removeChildren, readHTMLTable)
 importMethodsFrom("XML", saveXML)
+
+importFrom("curl", curl_unescape)
 
 importFrom("httr", GET, HEAD, POST, config, user_agent, set_cookies, content,
            upload_file)

--- a/R/quickload.R
+++ b/R/quickload.R
@@ -115,7 +115,7 @@ QuickloadGenome_annotFiles <- function(x) {
 
 setMethod("names", "QuickloadGenome", function(x) {
   x_mcols <- mcols(x)
-  structure(sapply(as.character(x_mcols$name), URLdecode),
+  structure(curl_unescape(as.character(x_mcols$name)),
             names = as.character(x_mcols$title))
 })
 
@@ -283,8 +283,8 @@ copyResourceToQuickload <- function(object, uri) {
   if (uriIsLocal(object_uri)) {
     dest_file <- file.path(object_uri$path, filename)
     if (paste(uri(object), filename, sep = "/") != uri)
-### FIXME: URLdecode() here because of R bug
-      download.file(URLdecode(uri), dest_file)
+### FIXME: curl_unescape() here because of R bug
+      download.file(curl_unescape(uri), dest_file)
   } else stop("Quickload is not local; cannot copy track")
   filename
 }

--- a/R/trackhub.R
+++ b/R/trackhub.R
@@ -912,8 +912,8 @@ copyResourceToTrackHub <- function(object, uri) {
         dest_file <- paste(object_uri$path, trackDbValue, filename, sep = "/")
         dest_file <- sub("^/", "", dest_file)
         if (paste(uri(object), filename, sep = "/") != uri)
-            ### FIXME: URLdecode() here because of R bug
-            download.file(URLdecode(uri), dest_file)
+            ### FIXME: curl_unescape() here because of R bug
+            download.file(curl_unescape(uri), dest_file)
     }
     else stop("TrackHub is not local; cannot copy track")
     filename

--- a/R/web.R
+++ b/R/web.R
@@ -52,7 +52,7 @@ urlEncode <- function(str, chars = "-a-zA-Z0-9$_.+!*'(),", keep = TRUE)
 
 urlDecode <- function(str, na.strings="NA")
 {
-  ans <- URLdecode(str)
+  ans <- curl_unescape(str)
   if (!identical(na.strings, "NA"))
       ans[is.na(str)] <- na.strings
   ans

--- a/man/readGFF.Rd
+++ b/man/readGFF.Rd
@@ -68,8 +68,8 @@ GFFcolnames(GFF1=FALSE)
           \link[GenomicRanges]{GRanges} object from a data frame or
           \link[S4Vectors]{DataFrame} object.
 
-    \item \code{\link[GenomicFeatures]{makeTxDbFromGFF}} in the
-          \pkg{GenomicFeatures} package for importing a GFF file as a
+    \item \code{\link[txdbmaker]{makeTxDbFromGFF}} in the
+          \pkg{txdbmaker} package for importing a GFF file as a
           \link[GenomicFeatures]{TxDb} object.
 
     \item The \link[S4Vectors]{DataFrame} class in the \pkg{S4Vectors}


### PR DESCRIPTION
This fixes a serious performance regression introduced by commit 81ca4c738c75fbefa3011007199da6f10928305b (part of my previous PR, PR #112) where I replaced the call to `RCurl::curlUnescape()` with a call to `utils::URLdecode()` in this line: https://github.com/lawremi/rtracklayer/blob/6bbc5509d511cbb7333c712c67a4f782584e265c/R/web.R#L55

Unfortunately the latter is about 100x slower than the former! :disappointed: 

This drastically impacts the speed of `readGFF()` when used on a big GFF file like the one used in [this example](https://github.com/Bioconductor/txdbmaker/issues/1#issue-2203386036). With **rtracklayer** 1.63.1:
```
gff <- "GCF_009914755.1_T2T-CHM13v2.0_genomic.gff.gz"
readGFF(gff)
```
takes more than 10 min!

This PR replaces all calls to `utils::URLdecode()` with calls to `curl::curl_unescape()`.

Note that performance of `curl::curl_unescape()` is similar to that of `RCurl::curlUnescape()`. With **rtracklayer** 1.63.2:
```
readGFF(gff)
```
takes < 1 min, like it did with versions of **rtracklayer** prior to 1.63.1.

Thanks,
H.

P.S.: Note that rtracklayer also uses `utils::URLencode()` in various places. However these calls were around before PR #112 and the PR didn't touch that so I'm leaving this alone. However, it might be worth considering replacing these calls with calls to `curl::curl_escape()` at some point.