### PR TITLE
Fix linking error on Windows/Rtools44

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rtracklayer
 Title: R interface to genome annotation files and the UCSC genome browser
-Version: 1.63.2
+Version: 1.63.3
 Author: Michael Lawrence, Vince Carey, Robert Gentleman
 Depends: R (>= 3.3), methods, GenomicRanges (>= 1.37.2)
 Imports: XML (>= 1.98-0), BiocGenerics (>= 0.35.3),

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,11 +1,14 @@
+LIBPSL = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libpsl.a),-lpsl),)
+LIBBROTLI = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
+
 ZLIB_CFLAGS+=$(shell echo 'zlibbioc::pkgconfig("PKG_CFLAGS")'|\
     "${R_HOME}/bin/R" --vanilla --slave)
 PKG_LIBS+=$(shell echo 'zlibbioc::pkgconfig("PKG_LIBS_shared")' |\
     "${R_HOME}/bin/R" --vanilla --slave)
 
-PKG_LIBS+=-lcurl -lssh2 -lssl -lz -lwldap32 -lbcrypt -lcrypto\
-    -lgcrypt -lcrypt32 -lgpg-error -lidn2 -lunistring -liconv\
-    -lzstd -lws2_32
+PKG_LIBS+=-lcurl $(LIBPSL) $(LIBBROTLI) -lssh2 -lssl -lwldap32\
+    -lbcrypt -lcrypto -lgcrypt -lcrypt32 -lgpg-error -lidn2\
+    -lunistring -liconv -lzstd -lws2_32 -lz
 include Makevars.common
 OBJECTS = $(PKG_OBJECTS) $(UCSC_OBJECTS:%=ucsc/%)
 


### PR DESCRIPTION
**rtraccklayer** doesn't install on Windows/Rtools44 because of a linking error. See https://bioconductor.org/checkResults/3.19/bioc-LATEST/rtracklayer/palomino3-install.html

This breaks hundreds of packages on Windows on the BioC 3.19 daily report: https://bioconductor.org/checkResults/3.19/bioc-LATEST/long-report.html

Please merge asap.

Thanks,
H.

P.S.: And sorry @lawremi if you received some mysterious emails from the CRAN winbuilder a couple of days ago. It was me testing this patch but forgetting to change the maintainer email first. Oops! 