### PR TITLE
Fix CURLINFO_FILETIME_T not available in ubuntu 18.04

### DIFF
--- a/src/ucsc/net.c
+++ b/src/ucsc/net.c
@@ -13,7 +13,7 @@
 
 time_t header_get_last_modified(CURL *curl) {
     curl_off_t last_modified;
-    CURLcode status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
+    CURLcode status = curl_easy_getinfo(curl, CURLINFO_FILETIME, &last_modified);
 
     if ((CURLE_OK == status) && (last_modified >= 0)) {
         struct tm *utc_tm_info = gmtime(&last_modified);


### PR DESCRIPTION
See https://github.com/lawremi/rtracklayer/issues/123