### PR TITLE
specify minimal libcurl version as SystemRequirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,6 +2,7 @@ Package: rtracklayer
 Title: R interface to genome annotation files and the UCSC genome browser
 Version: 1.65.0
 Author: Michael Lawrence, Vince Carey, Robert Gentleman
+SystemRequirements: libcurl (>=7.55)
 Depends: R (>= 3.3), methods, GenomicRanges (>= 1.37.2)
 Imports: XML (>= 1.98-0), BiocGenerics (>= 0.35.3),
          S4Vectors (>= 0.23.18), IRanges (>= 2.13.13), XVector (>= 0.19.7),


### PR DESCRIPTION
`rtracklayer` uses 
[CURLINFO_ACTIVESOCKET](https://curl.se/libcurl/c/CURLINFO_ACTIVESOCKET.html) (Added in curl 7.45.0 ) and
[CURLINFO_CONTENT_LENGTH_DOWNLOAD_T](https://curl.se/libcurl/c/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.html) (Added in curl 7.55.0 ). Centos 7's (EOL was just a month ago) comes with  libcurl/7.29.0.

Instead of only conditionally using these like
https://github.com/lawremi/rtracklayer/commit/3029741fd3f293544ba0eb72b2845ce92a683139 does for CURLINFO_FILETIME_T 
this PR just makes the requirement explicit to simplify installation if these requirements are unmet.
