### PR TITLE
Add checks for remaining MACROS to handle older libcurl

### DIFF
--- a/src/ucsc/net.c
+++ b/src/ucsc/net.c
@@ -12,21 +12,15 @@
 #include "cheapcgi.h"
 
 time_t header_get_last_modified(CURL *curl) {
-    CURLcode status;
     curl_off_t last_modified;
 
-    curl_version_info_data *ver = curl_version_info(CURLVERSION_NOW);
-    unsigned int major = (ver->version_num >> 16) & 0xff;
-    unsigned int minor = (ver->version_num >> 8) & 0xff;
-    unsigned int patch = ver->version_num & 0xff;
+    #if LIBCURL_VERSION_NUM >= 0x073b00
+        #define FILETIME CURLINFO_FILETIME_T
+    #else
+        #define FILETIME CURLINFO_FILETIME
+    #endif
 
-    if (major > 7)
-        status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
-    if (major == 7 && minor >= 59 && patch >= 0)
-        status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
-    else
-        status = curl_easy_getinfo(curl, CURLINFO_FILETIME, &last_modified);
-
+    CURLcode status = curl_easy_getinfo(curl, FILETIME, &last_modified);
 
     if ((CURLE_OK == status) && (last_modified >= 0)) {
         struct tm *utc_tm_info = gmtime(&last_modified);

--- a/src/ucsc/net.c
+++ b/src/ucsc/net.c
@@ -12,8 +12,21 @@
 #include "cheapcgi.h"
 
 time_t header_get_last_modified(CURL *curl) {
+    CURLcode status;
     curl_off_t last_modified;
-    CURLcode status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
+
+    curl_version_info_data *ver = curl_version_info(CURLVERSION_NOW);
+    unsigned int major = (ver->version_num >> 16) & 0xff;
+    unsigned int minor = (ver->version_num >> 8) & 0xff;
+    unsigned int patch = ver->version_num & 0xff;
+
+    if (major > 7)
+        status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
+    if (major == 7 && minor >= 59 && patch >= 0)
+        status = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &last_modified);
+    else
+        status = curl_easy_getinfo(curl, CURLINFO_FILETIME, &last_modified);
+
 
     if ((CURLE_OK == status) && (last_modified >= 0)) {
         struct tm *utc_tm_info = gmtime(&last_modified);


### PR DESCRIPTION
Leftover fix for #123. As mentioned in #123, It should have failed at the build time. However, I could not reproduce it even with Docker, which is really weird!!

So, I added a checks based on the version of the macros used. This should fix the issue.

| Macros, Data types, Functions                   | Introduced in Version    |
|----------------------------------------|------------|
| CURLINFO_FILETIME_T                   | 7.59.0     |
| (failback)CURLINFO_FILETIME                   | 7.5        |
| CURLINFO_CONTENT_LENGTH_DOWNLOAD_T     | 7.55.0     |
|(failback)CURLINFO_CONTENT_LENGTH_DOWNLOAD     | 7.6.1      |
| CURLOPT_URL                            | 7.1        |
| CURLOPT_NOBODY                         | 7.1        |
| CURLOPT_HEADER                          | 7.1        |
| CURLOPT_WRITEFUNCTION                  | 7.1        |
| CURLOPT_HEADERFUNCTION                 | 7.7.2      |
| CURLOPT_HEADERDATA                     | 7.10       |
| CURLOPT_OPENSOCKETDATA                | 7.17.1     |
| CURLINFO_ACTIVESOCKET                 | 7.45.0     |
| (failback)CURLINFO_LASTSOCKET                 | 7.15.2     |
| CURLOPT_RANGE                          | 7.1        |
| CURLOPT_FOLLOWLOCATION                 | 7.1        |
| CURLINFO_EFFECTIVE_URL                | 7.4        |
| CURL_GLOBAL_DEFAULT                    | 7.8        |
| CURL                                   | 7.1 (approx) |
| curl_off_t                            | 7.1 (approx) |
| CURLcode                               | 7.1 (approx) |
| curl_socket_t                          | 7.17.1 (approx) |
| curl_global_init()                     | 7.8        |
| curl_global_cleanup()                  | 7.8        |
| curl_easy_init()                       | 7.1        |
| curl_easy_setopt()                     | 7.1        |
| curl_easy_getinfo()                   | 7.4.1      |
| curl_easy_perform()                   | 7.1        |
| curl_easy_strerror()                  | 7.12.0     |