### PR TITLE
refactor(bigBed): use bigBedAsOrDefault for AutoSQL parsing

### DIFF
--- a/R/bigBed.R
+++ b/R/bigBed.R
@@ -21,7 +21,9 @@ setMethod("seqinfo", "BigBedFile", function(x) {
   Seqinfo(names(seqlengths), seqlengths)
 })
 
-.defaultColNames <- c("name", "score", "thick", "itemRgb", "blocks")
+.defaultColNames <- c("chrom", "chromStart", "chromEnd", "name", "score",
+                      "strand", "thickStart", "thickEnd", "itemRgb",
+                      "blockCount", "blockSizes", "blockStarts")
 
 setClass("BigBedSelection", prototype = prototype(colnames = .defaultColNames),
          contains = "RangedSelection")
@@ -57,71 +59,123 @@ setMethod("import.bb", "ANY", function(con, ...) {
 
 setMethod("import", "BigBedFile",
           function(con, format, text, selection = BigBedSelection(which, ...),
-                   which = con, ...)
-          {
+                   which = con, ...) {
+
             if (!missing(format))
               checkArgFormat(con, format)
             si <- seqinfo(con)
-            selection <- as(selection, "BigBedSelection")
+
+            # If which is NULL, create a GRanges spanning all sequences full length
+            if (is.null(which)) {
+              full_ranges <- IRanges(start = rep(1, length(seqlengths(si))),
+                                    end = seqlengths(si))
+              which <- GRanges(seqnames = seqlevels(si), ranges = full_ranges)
+              selection <- BigBedSelection(which)
+            } else {
+              selection <- as(selection, "BigBedSelection")
+            }
+
+            col_names <- colnames(selection)
+            # Get all available field names from bigBed file
+            fields_name <- .Call(BBDFile_fieldnames, expandPath(path(con)))
+            fields_name <- c(fields_name[[1L]], fields_name[[2L]])
+            # always prefer file field names if the user did not provide any
+            if (identical(col_names, .defaultColNames))
+                col_names <- fields_name
+            required_fields <- c("chrom", "chromStart", "chromEnd")
+            missing_fields <- setdiff(required_fields, col_names)
+            col_names <- c(col_names, missing_fields)
+            # set the selected colnames back
+            colnames(selection) <- col_names
+            unavailable_fields <- setdiff(col_names, fields_name)
+            unavailable_fields <- setdiff(unavailable_fields, .defaultColNames)
+            if (length(unavailable_fields) > 0L)
+                warning(paste("Unavailable field(s):",
+                        paste(unavailable_fields, collapse = ", ")))
+
+            # Extract and sanitize ranges against seqlevels in file
             ranges <- ranges(selection)
             badSpaces <- setdiff(names(ranges)[lengths(ranges) > 0L], seqlevels(si))
             if (length(badSpaces) > 0L)
               warning("'which' contains seqnames not known to BigBed file: ",
                       paste(badSpaces, collapse = ", "))
             ranges <- ranges[names(ranges) %in% seqlevels(si)]
+
+            # Flatten and split by seqlevels for querying
             flatranges <- unlist(ranges, use.names = FALSE)
             if (is.null(flatranges))
               flatranges <- IRanges()
             which_rl <- split(flatranges, factor(space(ranges), seqlevels(si)))
             which <- GRanges(which_rl)
-            allFields <- .Call(BBDFile_fieldnames, expandPath(path(con)))
-            defaultFields <- allFields[[1L]]
-            ValidextraFields <- allFields[[2L]]
-            selectedFields <- colnames(selection)
-            extraFields <- setdiff(selectedFields, defaultFields)
-            if (identical(colnames(BigBedSelection()), selectedFields)) {
-              selectedFields <- defaultFields[defaultFields != ""]
-              extraFields <- ValidextraFields[ValidextraFields != ""]
-            }
-            if (!identical(selectedFields, defaultFields)) {
-              defaultFields <- defaultFields[defaultFields != ""]
-              ValidextraFields <- ValidextraFields[ValidextraFields != ""]
-              defaultFieldIndexes <- which(defaultFields %in% selectedFields)
-              extraFieldIndexes <- which(ValidextraFields %in% extraFields)
-              invalidFields <- setdiff(extraFields, ValidextraFields)
-              if (length(defaultFieldIndexes) == 0L)
-                defaultFieldIndexes <- c(0L)
-              if (length(extraFieldIndexes) == 0L)
-                extraFieldIndexes <- c(0L)
-              if (length(invalidFields))
-                warning("Invalid ", invalidFields, " field(s)")
-            }else {
-              defaultFieldIndexes <- c()
-              extraFieldIndexes <- c()
-            }
-            defaultNames <- defaultFields[defaultFields %in% selectedFields]
-            extraNames <- ValidextraFields[ValidextraFields %in% extraFields]
+
             C_ans <- .Call(BBDFile_query, expandPath(path(con)),
                            as.character(seqnames(which)), ranges(which),
-                           defaultFieldIndexes, extraFieldIndexes)
-            nhits <- C_ans[[1L]]
-            gr <- GRanges(rep(seqnames(which), nhits), C_ans[[3L]], seqinfo=si)
-            if (!is.null(C_ans[[4L]]))
-              strand(gr) <- gsub(".", "*", C_ans[[4L]], fixed = TRUE)
-            blocksPosition <- which(defaultNames %in% c("blocks"))
-            if (length(blocksPosition)) {
-              blocksPosition <- 4 + blocksPosition
-              C_ans[[blocksPosition]] <- IRangesList(C_ans[[blocksPosition]])
+                           colnames(selection))
+
+
+            nhits <- C_ans[["n_qhits"]]
+            # Reconstruct GRanges with genomic coordinates and seqinfo
+            result_seqnames <- C_ans[["chrom"]]
+            chromStart <- C_ans[["chromStart"]]
+            chromEnd <- C_ans[["chromEnd"]]
+            # to 1 based
+            chromStart <- chromStart + 1L
+            chromWidth <- chromEnd - chromStart
+            result_ranges <- IRanges(start = chromStart, width = chromWidth)
+            gr <- GRanges(result_seqnames, result_ranges, seqinfo = si)
+
+            if ("strand" %in% names(C_ans) && !is.null(C_ans[["strand"]])) {
+                cleaned_strand <- gsub("\\.", "*", C_ans[["strand"]])
+                strand(gr) <- factor(cleaned_strand, levels = c("+", "-", "*"))
             }
-            val <- c()
-            if (length(defaultFieldIndexes) && defaultFieldIndexes[1] != 0)
-              val <- c(Filter(Negate(is.null), C_ans[5L:length(C_ans)]))
-            val <- c(val, Filter(Negate(is.null), C_ans[[2L]]))
-            elementMetadata <- DataFrame(val)
-            names(elementMetadata) <- c(defaultNames ,extraNames)
-            gr@elementMetadata <- elementMetadata
-            gr
-           })
+
+            if ("thickStart" %in% names(C_ans) && !is.null(C_ans[["thickStart"]])) {
+                # convert 0-based to 1-based start
+                thickStart <- C_ans[["thickStart"]] + 1L
+                thickEnd <- C_ans[["thickEnd"]]
+
+                if (!is.null(thickEnd) && length(thickStart) == length(thickEnd)) {
+                    thick <- IRanges(start = thickStart, end = thickEnd)
+                    mcols(gr)$thick <- thick
+                } else {
+                    warning("thickEnd not found or length mismatch with thickStart")
+                }
+            }
+
+            if ("blockCount" %in% names(C_ans) && !is.null(C_ans[["blockCount"]])) {
+                blockCount <- C_ans[["blockCount"]]
+                blockSizes <- C_ans[["blockSizes"]]
+                blockStarts <- C_ans[["blockStarts"]]
+                # Convert blockStarts from 0-based to 1-based coordinates
+                ir_list <- IRanges(start = blockStarts + 1L, width = blockSizes)
+                blocks <- relist(ir_list, PartitioningByWidth(blockCount))
+                names(blocks) <- NULL
+                mcols(gr)$blocks <- blocks
+            }
+
+            if ("itemRgb" %in% names(C_ans) && !is.null(C_ans[["itemRgb"]])) {
+                color <- C_ans[["itemRgb"]]
+                spec <- color != "0"
+                cols <- unlist(strsplit(color[spec], ",", fixed=TRUE),
+                               use.names=FALSE)
+                cols <- matrix(as.integer(cols), 3)
+                color <- rep(NA, length(gr))
+                color[spec] <- rgb(cols[1,], cols[2,], cols[3,],
+                                   maxColorValue = 255L)
+                mcols(gr)$itemRgb <- color
+            }
+
+            processed_fields <- c("n_qhits", "chrom", "chromStart", "chromEnd",
+                                  "strand", "thickStart", "thickEnd",
+                                  "blockCount", "blockSizes", "blockStarts",
+                                  "itemRgb")
+            remaining_fields <- setdiff(names(C_ans), processed_fields)
+            for (field in remaining_fields)
+                mcols(gr)[[field]] <- C_ans[[field]]
+
+           gr
+          })
+
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Export

--- a/R/bigBed.R
+++ b/R/bigBed.R
@@ -120,8 +120,7 @@ setMethod("import", "BigBedFile",
             chromEnd <- C_ans[["chromEnd"]]
             # to 1 based
             chromStart <- chromStart + 1L
-            chromWidth <- chromEnd - chromStart
-            result_ranges <- IRanges(start = chromStart, width = chromWidth)
+            result_ranges <- IRanges(start = chromStart, chromEnd)
             gr <- GRanges(result_seqnames, result_ranges, seqinfo = si)
 
             if ("strand" %in% names(C_ans) && !is.null(C_ans[["strand"]])) {
@@ -252,7 +251,7 @@ bedString <- function(x) {
   thickStart <- NULL
   thickEnd <- NULL
   if (!is.null(thick)) {
-    thickStart <- start(ranges(thick))
+    thickStart <- start(ranges(thick)) - 1L
     thickEnd <- end(ranges(thick))
     elementMetadata$thick <- NULL
   }
@@ -267,11 +266,11 @@ bedString <- function(x) {
     length <- length(blocks)
     blockCount <- lengths(blocks)
     blockSizes <- lapply(width(blocks), function(x) paste(x, collapse=","))
-    blockStarts <- lapply(start(blocks), function(x) paste(x, collapse=","))
+    blockStarts <- lapply(start(blocks) - 1L, function(x) paste(x, collapse=","))
     elementMetadata$blocks <- NULL
   }
   extraColumnsString <- do.call(paste, as.list(elementMetadata))
-  paste(as.character(seqnames(x)), start(ranges(x)), end(ranges(x)), name, score,
+  paste(as.character(seqnames(x)), start(ranges(x)) - 1L, end(ranges(x)), name, score,
                      strand, thickStart, thickEnd, itemRgb, blockCount, blockSizes,
                      blockStarts, extraColumnsString, collapse = "\n")
 }

--- a/inst/unitTests/test_bb.R
+++ b/inst/unitTests/test_bb.R
@@ -6,7 +6,8 @@ test_bb <- function() {
   test_bb <- file.path(test_path, "test.bb")
   start <- c(237640, 521500 ,565725, 565900, 566760,
              119905, 122525, 173925, 179865, 180185)
-  ir <- IRanges(start, width = 151)
+  start <- start + 1L
+  ir <- IRanges(start, width = 150)
   space <- factor(c(rep("chr1", 5), rep("chr10", 5)))
   name <- rep(".", 10)
   score <- seq.int(70L, 700L, length = 10)
@@ -39,7 +40,6 @@ test_bb <- function() {
                  selection = BigBedSelection(which, colnames = character()))
   correct_subset <- subsetByOverlaps(correct_fixed, which)
   correct_which <- correct_subset[, character()]
-  correct_which@elementMetadata <- DataFrame()
   checkIdentical(test, correct_which)
 
   ## TEST: BigBedSelection (GRanges, 1 default field)

--- a/inst/unitTests/test_ucsc.R
+++ b/inst/unitTests/test_ucsc.R
@@ -31,7 +31,8 @@ test_ucsc <- function(x) {
     # creating a track for Track Hub
     start <- c(237640, 521500 ,565725, 565900, 566760,
                119905, 122525, 173925, 179865, 180185)
-    ir <- IRanges(start, width = 151)
+    start <- start + 1L
+    ir <- IRanges(start, width = 150)
     space <- factor(c(rep("chr1", 5), rep("chr10", 5)))
     name <- rep(".", 10)
     score <- seq.int(70L, 700L, length = 10)

--- a/man/BigBedSelection.rd
+++ b/man/BigBedSelection.rd
@@ -11,12 +11,20 @@
 \title{Selection of ranges and columns}
 
 \description{A \code{BigBedSelection} represents a query against a
-  BigBed file, see \code{\link{import.bb}}. It is simply
-  a \link[IRanges]{RangedSelection} with \code{colnames}
-  parameter.\code{colnames} should be a character vector of column names.
-  Default columns are \code{"name", "score", "thick", "itemRgb"}
-  and \code{"blocks"}, if non-empty, as that is the only column supported
-  by BigBed.}
+  BigBed file, see \code{\link{import.bb}}. It extends
+  \link[IRanges]{RangedSelection} by including a \code{colnames} parameter.
+  The \code{colnames} should be a character vector of column names
+  corresponding to BigBed fields.
+
+  By default, \code{colnames} correspond to the standard BED12 format fields
+  that cover core interval data, strand, display attributes, and block (exon)
+  structure information.
+
+  If no custom \code{colnames} are provided, \pkg{rtracklayer} attempts to use
+  the field names present in the BigBed file itself. Since BigBed files can
+  contain non standard or additional custom fields beyond the standard ones,
+  this allows flexible access to such extended fields in the query results.
+}
 
 \section{Constructor}{
   \describe{

--- a/src/R_init_rtracklayer.c
+++ b/src/R_init_rtracklayer.c
@@ -28,7 +28,7 @@ static const R_CallMethodDef callMethods[] = {
   /* bigBed.c */
   CALLMETHOD_DEF(BBDFile_fieldnames, 1),
   CALLMETHOD_DEF(BBDFile_seqlengths, 1),
-  CALLMETHOD_DEF(BBDFile_query, 5),
+  CALLMETHOD_DEF(BBDFile_query, 4),
   CALLMETHOD_DEF(BBDFile_write, 6),
   /* twobit.c */
   CALLMETHOD_DEF(DNAString_to_twoBit, 3),

--- a/src/bigBed.c
+++ b/src/bigBed.c
@@ -26,34 +26,30 @@ SEXP BBDFile_fieldnames(SEXP r_filename)
 {
   pushRHandlers();
   struct bbiFile *file = bigBedFileOpen((char *)CHAR(asChar(r_filename)));
-  char *asText = bigBedAutoSqlText(file);
-  struct asObject *as = asParseText(asText);
-  freeMem(asText);
+  struct asObject *as = bigBedAsOrDefault(file);
+  struct asColumn *asCol = as->columnList;
+
   int fieldCount = file->fieldCount;
   int definedFieldCount = getDefinedFieldCount(as);
   bigBedFileClose(&file);
-  char *names[] = {"name", "score", "thick", "itemRgb", "blocks"};
-  struct asColumn *asCol = as->columnList;
+
   SEXP defaultFields = PROTECT(allocVector(STRSXP, definedFieldCount));
   SEXP extraFields = PROTECT(allocVector(STRSXP, fieldCount - definedFieldCount));
+
+  int extraIndex = 0;
   for (int i = 0; i < fieldCount; ++i) {
-    if (i >= definedFieldCount)
-      SET_STRING_ELT(extraFields, i - definedFieldCount, mkChar(asCol->name));
-    else if (i == 3)
-      SET_STRING_ELT(defaultFields, i, mkChar(names[0]));
-    else if (i == 4)
-      SET_STRING_ELT(defaultFields, i, mkChar(names[1]));
-    else if (i == 7)
-      SET_STRING_ELT(defaultFields, i, mkChar(names[2]));
-    else if (i == 8)
-      SET_STRING_ELT(defaultFields, i, mkChar(names[3]));
-    else if (i == 11)
-      SET_STRING_ELT(defaultFields, i, mkChar(names[4]));
+    if (i < definedFieldCount)
+      SET_STRING_ELT(defaultFields, i, mkChar(asCol->name));
+    else
+      SET_STRING_ELT(extraFields, extraIndex++, mkChar(asCol->name));
+
     asCol = asCol->next;
   }
+
   SEXP list = PROTECT(allocVector(VECSXP, 2));
   SET_VECTOR_ELT(list, 0, defaultFields);
   SET_VECTOR_ELT(list, 1, extraFields);
+
   asObjectFree(&as);
   popRHandlers();
   UNPROTECT(3);
@@ -93,9 +89,7 @@ SEXP BBDFile_query(SEXP r_filename, SEXP r_seqnames, SEXP r_ranges,
   }
 
   /* need these before closing file */
-  char *asText = bigBedAutoSqlText(file);
-  struct asObject *as = asParseText(asText);
-  freeMem(asText);
+  struct asObject *as = bigBedAsOrDefault(file);
   int fieldCount = file->fieldCount;
   int definedFieldCount = getDefinedFieldCount(as);
   int extraFieldCount = fieldCount - definedFieldCount;

--- a/src/bigBed.c
+++ b/src/bigBed.c
@@ -56,217 +56,200 @@ SEXP BBDFile_fieldnames(SEXP r_filename)
   return list;
 }
 
+static struct bigBedInterval *queryIntervals(struct bbiFile *file,
+                                             SEXP r_seqnames,
+                                             int *start, int *width,
+                                             int n_ranges,
+                                             SEXP n_qhits,
+                                             struct lm *lm) {
+    struct bigBedInterval *hits = NULL, *tail = NULL;
+    for (int i = 0; i < n_ranges; ++i) {
+        struct bigBedInterval *queryHits =
+            bigBedIntervalQuery(file, (char *)CHAR(STRING_ELT(r_seqnames, i)),
+                                start[i] - 1, start[i] - 1 + width[i], 0, lm);
+        if (!hits) {
+            hits = queryHits;
+        } else {
+            tail->next = queryHits;
+        }
+        if (queryHits)
+            tail = slLastEl(queryHits);
+        INTEGER(n_qhits)[i] = slCount(queryHits);
+    }
+    return hits;
+}
+
+static SEXPTYPE mapAsTypeToRType(enum asTypes ftype) {
+    if (asTypesIsFloating(ftype))
+        return REALSXP;
+
+    switch (ftype) {
+        case t_int:
+        case t_short:
+        case t_ushort:
+        case t_byte:
+        case t_ubyte:
+        case t_uint:
+        /* Assumes values fit in signed 32-bit range (typical genomic coords) */
+            return INTSXP;
+
+        /* 64-bit integer stored as double (no native 64-bit int in base R) */
+        case t_off:
+            return REALSXP;
+
+        case t_char:
+        case t_string:
+        case t_lstring:
+            return STRSXP;
+
+        default:
+            return STRSXP;
+    }
+}
+
+static SEXP prepareFieldContainers(struct asObject *as,
+                                   int fieldCount, int definedFieldCount,
+                                   int n_hits, SEXP r_colnames,
+                                   SEXPTYPE *fieldTypes,
+                                   int *unprotectCount) {
+    struct asColumn *asCol = as->columnList;
+    SEXP fieldList = PROTECT(allocVector(VECSXP, fieldCount));
+    SEXP fieldNames = PROTECT(allocVector(STRSXP, fieldCount));
+    *unprotectCount += 2;
+
+    struct hash *colHash = hashNew(0);
+    int n_colnames = LENGTH(r_colnames);
+    for (int k = 0; k < n_colnames; ++k) {
+        hashAdd(colHash, (char *)CHAR(STRING_ELT(r_colnames, k)), NULL);
+    }
+
+    for (int j = 0; j < fieldCount; ++j, asCol = asCol->next) {
+        char *colName = asCol->name;
+
+        if (colName)
+            SET_STRING_ELT(fieldNames, j, mkChar(colName));
+        else
+            SET_VECTOR_ELT(fieldNames, j, R_NilValue);
+
+        bool selected = (colName && hashLookup(colHash, colName) != NULL);
+
+        if (!selected) {
+            SET_VECTOR_ELT(fieldList, j, R_NilValue);
+            continue;
+        }
+
+        fieldTypes[j] = mapAsTypeToRType(asCol->lowType->type);
+        SET_VECTOR_ELT(fieldList, j, allocVector(fieldTypes[j], n_hits));
+        PROTECT(VECTOR_ELT(fieldList, j));
+        ++(*unprotectCount);
+    }
+    setAttrib(fieldList, R_NamesSymbol, fieldNames);
+    hashFree(&colHash);
+    return fieldList;
+}
+
+static void fillResults(struct bigBedInterval *hits,
+                        SEXP n_qhits, int n_ranges, int fieldCount,
+                        int definedFieldCount, SEXPTYPE *fieldTypes,
+                        SEXP fieldList, SEXP r_seqnames) {
+    char startBuf[16], endBuf[16], *row[fieldCount];
+    int i = 0, rangeIndex = 0, count = 0;
+
+    for (struct bigBedInterval *bb = hits; bb; bb = bb->next, ++i, ++count) {
+        if (rangeIndex < n_ranges && count == INTEGER(n_qhits)[rangeIndex]) {
+            ++rangeIndex;
+            count = 0;
+        }
+
+        bigBedIntervalToRow(bb, (char *)CHAR(STRING_ELT(r_seqnames, rangeIndex)),
+                            startBuf, endBuf, row, fieldCount);
+
+        for (int j = 0; j < fieldCount; ++j) {
+            if (VECTOR_ELT(fieldList, j) == R_NilValue)
+                continue;
+
+            switch (fieldTypes[j]) {
+                case REALSXP:
+                    REAL(VECTOR_ELT(fieldList, j))[i] = sqlDouble(row[j]);
+                    break;
+                case INTSXP:
+                    INTEGER(VECTOR_ELT(fieldList, j))[i] = sqlSigned(row[j]);
+                    break;
+                case STRSXP:
+                    SET_STRING_ELT(VECTOR_ELT(fieldList, j), i, mkChar(row[j]));
+                    break;
+            }
+        }
+    }
+}
+
+static SEXP wrapResults(SEXP n_qhits, SEXP fieldList, int fieldCount,
+                        int *unprotectCount) {
+    int listSize = 2 + fieldCount;  // (n_qhits, fields)
+    SEXP ans = PROTECT(allocVector(VECSXP, listSize));
+    ++(*unprotectCount);
+
+    int idx = 0;
+    SET_VECTOR_ELT(ans, idx++, n_qhits);
+    for (int j = 0; j < fieldCount; ++j) {
+        SET_VECTOR_ELT(ans, idx++, VECTOR_ELT(fieldList, j));
+    }
+
+    SEXP ansNames = PROTECT(allocVector(STRSXP, listSize));
+    ++(*unprotectCount);
+    SET_STRING_ELT(ansNames, 0, mkChar("n_qhits"));
+
+    SEXP fieldNames = getAttrib(fieldList, R_NamesSymbol);
+    for (int j = 0; j < fieldCount; ++j) {
+        SET_STRING_ELT(ansNames, j + 1, STRING_ELT(fieldNames, j));
+    }
+
+    setAttrib(ans, R_NamesSymbol, ansNames);
+    return ans;
+}
+
 /* --- .Call ENTRY POINT --- */
 SEXP BBDFile_query(SEXP r_filename, SEXP r_seqnames, SEXP r_ranges,
-                   SEXP r_defaultindex, SEXP r_extraindex)
-{
-  pushRHandlers();
-  struct bbiFile *file = bigBedFileOpen((char *)CHAR(asChar(r_filename)));
-  struct lm *lm = lmInit(0);
-  int n_ranges = get_IRanges_length(r_ranges);
-  int *start = INTEGER(get_IRanges_start(r_ranges));
-  int *width = INTEGER(get_IRanges_width(r_ranges));
+                   SEXP r_colnames) {
+    pushRHandlers();
 
-  SEXP ans, n_qhits, ranges, chromStart, chromWidth, name, score,
-    strand = R_NilValue, thickStart, thickWidth, itemRgb, blocks,
-    extraFields = R_NilValue, lengthIndex;
+    int unprotectCount = 0;
+    const char *fname = CHAR(asChar(r_filename));
+    struct bbiFile *file = bigBedFileOpen((char *)fname);
+    struct lm *lm = lmInit(0);
 
-  n_qhits = PROTECT(allocVector(INTSXP, n_ranges));
-  struct bigBedInterval *hits = NULL, *tail = NULL;
-  /* querying records in range */
-  for (int i = 0; i < n_ranges; ++i) {
-    struct bigBedInterval *queryHits =
-      bigBedIntervalQuery(file, (char *)CHAR(STRING_ELT(r_seqnames, i)),
-                          start[i] - 1, start[i] - 1 + width[i], 0, lm);
-    if (!hits) {
-      hits = queryHits;
-      tail = slLastEl(hits);
-    } else {
-      tail->next = queryHits;
-      tail = slLastEl(tail);
-    }
-    INTEGER(n_qhits)[i] = slCount(queryHits);
-  }
+    int n_ranges = get_IRanges_length(r_ranges);
+    int *start   = INTEGER(get_IRanges_start(r_ranges));
+    int *width   = INTEGER(get_IRanges_width(r_ranges));
 
-  /* need these before closing file */
-  struct asObject *as = bigBedAsOrDefault(file);
-  int fieldCount = file->fieldCount;
-  int definedFieldCount = getDefinedFieldCount(as);
-  int extraFieldCount = fieldCount - definedFieldCount;
-  int n_hits = slCount(hits);
-  bigBedFileClose(&file);
-
-  int presentFieldCount = 0, unprotectCount = 0;
-  /* mandatory default field */
-  chromStart = PROTECT(allocVector(INTSXP, n_hits));
-  chromWidth = PROTECT(allocVector(INTSXP, n_hits));
-  /* if any of the default field is present and selected, allocate memory for it */
-  if (isPresent(definedFieldCount, i_name) && isSelected(r_defaultindex, 1)) {
-    name = PROTECT(allocVector(STRSXP, n_hits));
-    ++presentFieldCount;
+    SEXP n_qhits = PROTECT(allocVector(INTSXP, n_ranges));
     ++unprotectCount;
-  }
-  if (isPresent(definedFieldCount, i_score) && isSelected(r_defaultindex, 2)) {
-    score = PROTECT(allocVector(INTSXP, n_hits));
-    ++presentFieldCount;
-    ++unprotectCount;
-  }
-  if (isPresent(definedFieldCount, i_strand)) {
-    strand = PROTECT(allocVector(STRSXP, n_hits));
-    ++unprotectCount;
-  }
-  if (isPresent(definedFieldCount, i_thick) && isSelected(r_defaultindex, 3)) {
-    thickStart = PROTECT(allocVector(INTSXP, n_hits));
-    thickWidth = PROTECT(allocVector(INTSXP, n_hits));
-    ++presentFieldCount;
-    unprotectCount += 2;
-  }
-  if (isPresent(definedFieldCount, i_itemRgb) && isSelected(r_defaultindex, 4)) {
-    itemRgb = PROTECT(allocVector(STRSXP, n_hits));
-    ++presentFieldCount;
-    ++unprotectCount;
-  }
-  if (isPresent(definedFieldCount, i_blocks) && isSelected(r_defaultindex, 5)) {
-      blocks = PROTECT(allocVector(VECSXP, n_hits));
-      ++presentFieldCount;
-      ++unprotectCount;
-  }
 
-  SEXPTYPE *typeId;
-  /* if extra fields are present and selected
-   * identify the type information and allocate memory */
-  if (extraFieldCount > 0) {
-    int k = 0;
-    enum asTypes fieldType;
-    struct asColumn *asCol = as->columnList;
-    extraFields = PROTECT(allocVector(VECSXP, extraFieldCount));
-    typeId = (SEXPTYPE*)R_alloc(extraFieldCount, sizeof(SEXPTYPE));
-    for (int j = 0; j < fieldCount; ++j) {
-      fieldType = asCol->lowType->type;
-      if (j >= definedFieldCount) {
-        if (asTypesIsFloating(fieldType) || fieldType == t_uint ||
-            fieldType == t_off) {
-          typeId[k] = REALSXP;
-        } else if (fieldType == t_int || fieldType == t_short ||
-                   fieldType == t_ushort || fieldType == t_byte) {
-          typeId[k] = INTSXP;
-        } else if (fieldType == t_char || fieldType == t_string ||
-                   fieldType == t_lstring) {
-          typeId[k] = STRSXP;
-        } else if (fieldType == t_ubyte) {
-          typeId[k] = RAWSXP;
-        }
-        if (isSelected(r_extraindex, (j - definedFieldCount + 1))) {
-          SEXP temp = PROTECT(allocVector(typeId[k], n_hits));
-          SET_VECTOR_ELT(extraFields, k, temp);
-          ++unprotectCount;
-          ++k;
-        }
-      }
-      asCol = asCol->next;
-    }
-    lengthIndex = PROTECT(allocVector(INTSXP, extraFieldCount));
-    memset(INTEGER(lengthIndex), 0, sizeof(int) * extraFieldCount);
-    unprotectCount += 2;
-  }
-  asObjectFree(&as);
+    struct bigBedInterval *hits = queryIntervals(file, r_seqnames, start, width,
+                                                 n_ranges, n_qhits, lm);
 
-  int count = 0, k = 0;
-  char startBuf[16], endBuf[16], *row[fieldCount], rgbBuf[8];
-  for (int i = 0; i < n_hits; ++i, hits = hits->next, ++count) {
-    if (INTEGER(n_qhits)[k] == count && k < n_ranges) {
-      ++k;
-      count = 0;
-    }
-    bigBedIntervalToRow(hits, (char *)CHAR(STRING_ELT(r_seqnames, k)),
-                        startBuf, endBuf, row, fieldCount);
-    struct bed *bed = bedLoadN(row, definedFieldCount);
-    /* mandatory default field */
-    INTEGER(chromStart)[i] = bed->chromStart;
-    INTEGER(chromWidth)[i] = bed->chromEnd - bed->chromStart + 1;
-    /* if any of the default field is present and selected, store its value */
-    if (isPresent(definedFieldCount, i_name) && isSelected(r_defaultindex, 1)) {
-      SET_STRING_ELT(name, i, mkChar(bed->name));
-    }
-    if (isPresent(definedFieldCount, i_score) && isSelected(r_defaultindex, 2)) {
-      INTEGER(score)[i] = bed->score;
-    }
-    if (isPresent(definedFieldCount, i_strand)) {
-      SET_STRING_ELT(strand, i, mkChar(bed->strand));
-    }
-    if (isPresent(definedFieldCount, i_thick) && isSelected(r_defaultindex, 3)) {
-      INTEGER(thickWidth)[i] = bed->thickEnd - bed->thickStart + 1;
-      INTEGER(thickStart)[i] = bed->thickStart;
-    }
-    if (isPresent(definedFieldCount, i_itemRgb) && isSelected(r_defaultindex, 4)) {
-      snprintf(rgbBuf, 8, "#%06x", bed->itemRgb);
-      SET_STRING_ELT(itemRgb, i, mkChar(rgbBuf));
-    }
-    if (isPresent(definedFieldCount, i_blocks) && isSelected(r_defaultindex, 5)) {
-      SEXP bstart = PROTECT(allocVector(INTSXP, bed->blockCount));
-      SEXP bwidth = PROTECT(allocVector(INTSXP, bed->blockCount));
-      for (int j = 0; j< bed->blockCount; ++j) {
-        INTEGER(bwidth)[j] = bed->blockSizes[j];
-        INTEGER(bstart)[j] = bed->chromStarts[j];
-      }
-      SET_VECTOR_ELT(blocks, i, new_IRanges("IRanges", bstart, bwidth, R_NilValue));
-      UNPROTECT(2);
-    }
-    bedFree(&bed);
+    struct asObject *as   = bigBedAsOrDefault(file);
+    int fieldCount        = file->fieldCount;
+    int definedFieldCount = getDefinedFieldCount(as);
+    int n_hits            = slCount(hits);
 
-    /* if extra fields are present and selected store their values */
-    for (int j = definedFieldCount, efIndex = 0 ; j < fieldCount; ++j) {
-      if (isSelected(r_extraindex, (j - definedFieldCount + 1))) {
-        switch(typeId[efIndex]) {
-          case REALSXP:
-            REAL(VECTOR_ELT(extraFields, efIndex))[i] = sqlDouble(row[j]);
-            break;
-          case INTSXP:
-            INTEGER(VECTOR_ELT(extraFields, efIndex))[i] = sqlSigned(row[j]);
-            break;
-          case STRSXP: {
-            int index = INTEGER(lengthIndex)[efIndex];
-            SET_STRING_ELT(VECTOR_ELT(extraFields, efIndex), index, mkChar(row[j]));
-            INTEGER(lengthIndex)[efIndex] = index + 1;
-            break;
-          }
-          case RAWSXP:
-            RAW(extraFields)[i] = sqlUnsigned(row[j]);
-            break;
-        }
-        ++efIndex;
-      }
-    }
-    freeMem(row[3]);
-  }
+    bigBedFileClose(&file);
 
-  ranges = PROTECT(new_IRanges("IRanges", chromStart, chromWidth, R_NilValue));
-  ans = PROTECT(allocVector(VECSXP, presentFieldCount + 4));
-  int index = 0;
-  SET_VECTOR_ELT(ans, index++, n_qhits);
-  SET_VECTOR_ELT(ans, index++, extraFields);
-  SET_VECTOR_ELT(ans, index++, ranges);
-  SET_VECTOR_ELT(ans, index++, strand);
-  if (isPresent(definedFieldCount, i_name) && isSelected(r_defaultindex, 1)) {
-    SET_VECTOR_ELT(ans, index++, name);
-  }
-  if (isPresent(definedFieldCount, i_score) && isSelected(r_defaultindex, 2)) {
-    SET_VECTOR_ELT(ans, index++, score);
-  }
-  if (isPresent(definedFieldCount, i_thick) && isSelected(r_defaultindex, 3)) {
-    SET_VECTOR_ELT(ans, index++, new_IRanges("IRanges", thickStart,
-                                             thickWidth, R_NilValue));
-  }
-  if (isPresent(definedFieldCount, i_itemRgb) && isSelected(r_defaultindex, 4)) {
-    SET_VECTOR_ELT(ans, index++, itemRgb);
-  }
-  if (isPresent(definedFieldCount, i_blocks) && isSelected(r_defaultindex, 5)) {
-    SET_VECTOR_ELT(ans, index++, blocks);
-  }
-  UNPROTECT(5 + unprotectCount);
-  lmCleanup(&lm);
-  popRHandlers();
-  return ans;
+    SEXPTYPE *fieldTypes = (SEXPTYPE*)R_alloc(fieldCount, sizeof(SEXPTYPE));
+    SEXP fieldList = prepareFieldContainers(as, fieldCount, definedFieldCount,
+                                            n_hits, r_colnames, fieldTypes,
+                                            &unprotectCount);
+
+    fillResults(hits, n_qhits, n_ranges, fieldCount, definedFieldCount,
+                fieldTypes, fieldList, r_seqnames);
+    SEXP ans = wrapResults(n_qhits, fieldList, fieldCount, &unprotectCount);
+
+    asObjectFree(&as);
+    lmCleanup(&lm);
+    UNPROTECT(unprotectCount);
+    popRHandlers();
+
+    return ans;
 }
 
 static struct hash *createIntHash(SEXP v) {

--- a/src/bigBed.h
+++ b/src/bigBed.h
@@ -8,7 +8,7 @@
 SEXP BBDFile_seqlengths(SEXP r_filename);
 SEXP BBDFile_fieldnames(SEXP r_filename);
 SEXP BBDFile_query(SEXP r_filename, SEXP r_seqnames, SEXP r_ranges,
-                   SEXP r_defaultindex, SEXP r_extraindex);
+                   SEXP r_colnames);
 SEXP BBDFile_write(SEXP r_seqlengths, SEXP r_bedString, SEXP r_autosql,
                    SEXP r_indexfields, SEXP r_compress, SEXP r_outfile);
 

--- a/src/bigBedHelper.c
+++ b/src/bigBedHelper.c
@@ -21,20 +21,6 @@ int getDefinedFieldCount(struct asObject *as) {
   return definedFieldCount;
 }
 
-bool isPresent(int definedFieldCount, int index) {
-  return (definedFieldCount - index >= 0) ? TRUE : FALSE;
-}
-
-bool isSelected(SEXP r_selectedindex, int position) {
-  if (length(r_selectedindex) == 0)
-    return TRUE;
-  for (int i = 0; i < length(r_selectedindex); ++i) {
-    if(INTEGER(r_selectedindex)[i] == position)
-      return TRUE;
-  }
-  return FALSE;
-}
-
 /* following functions are taken from the kent library */
 
 struct rbTree *rangeTreeForBedChrom(struct lineFile *lf, char *chrom)

--- a/src/ucsc/bigBed.h
+++ b/src/ucsc/bigBed.h
@@ -80,5 +80,8 @@ int bigBedIntervalToRow(struct bigBedInterval *interval, char *chrom, char *star
 char *bigBedAutoSqlText(struct bbiFile *bbi);
 /* Get autoSql text if any associated with file.  Do a freeMem of this when done. */
 
+
+struct asObject *bigBedAsOrDefault(struct bbiFile *bbi);
+
 #endif /* BIGBED_H */
 


### PR DESCRIPTION
Going to fix : #142  and #77 

- [x] With bigBedAsOrDefault() that returns either the parsed AutoSQL schema or a default BED12 schema if no AutoSQL is present.

- [x] After fixing parsing of AutoSQL, column selection implementation is causing a crash. Either way, it is implemented poorly. Going to refactor it too. 
- [x] Update documentation 
- [x] Update test
